### PR TITLE
Generate full-diff.patch in PR reviews when incremental is true

### DIFF
--- a/scripts/review-pr.ts
+++ b/scripts/review-pr.ts
@@ -145,7 +145,7 @@ Compliance information is located in AGENTS.md and README.md.
 - If there are zero findings, your summary must state that no actionable findings were identified, and you must not fabricate filler content.
 
 ${incremental
-    ? `The PR DIFF in \`.review-context/diff.patch\` only covers changes since the last review round. The full comment history of the PR is available in \`.review-context/comments.md\`.
+    ? `The PR DIFF in \`.review-context/diff.patch\` only covers changes since the last review round. The full unified diff of all changes in the PR is available in \`.review-context/full-diff.patch\`. The full comment history of the PR is available in \`.review-context/comments.md\`.
 Read \`.review-context/comments.md\` to determine if previously reported blocking findings are now resolved, still open, or no longer applicable.
 - Treat a prior finding as still open unless the comment history and current diff together indicate it was addressed — i.e., silence in the incremental diff about a prior finding is not evidence of resolution.
 - Do not re-raise a prior finding as newly reported once you judge it addressed; instead, acknowledge it as 'resolved' in the finding output.
@@ -221,6 +221,14 @@ async function main() {
     }
   }
   writeFileSync(join(contextDir, 'diff.patch'), diff);
+  if (incremental) {
+    try {
+      const fullDiff = getFilteredDiff(`${baseSha}...${headSha}`);
+      writeFileSync(join(contextDir, 'full-diff.patch'), fullDiff);
+    } catch (e) {
+      console.warn('[review-pr] Failed to generate full diff:', e);
+    }
+  }
 
   let prMetaMd = '_No description provided._';
   try {
@@ -236,11 +244,15 @@ async function main() {
 
   const hasDiffStat = existsSync(join(contextDir, 'diff-stat.txt'));
 
-  const manifest = `# PR Review Context Files
-- \`diff.patch\`: A standard unified diff of the changes in this PR${incremental ? ' since the last review' : ''}.
-${hasDiffStat ? '- `diff-stat.txt`: A summary of the changed files and lines.\n' : ''}- \`pr-meta.md\`: The PR title and description.
-- \`comments.md\`: The full comment history of the PR.
-`;
+  const hasFullDiff = existsSync(join(contextDir, 'full-diff.patch'));
+  const manifest = [
+    '# PR Review Context Files',
+    `- \`diff.patch\`: A standard unified diff of the changes in this PR${incremental ? ' since the last review' : ''}.`,
+    hasFullDiff ? '- \`full-diff.patch\`: The full unified diff of all changes in this PR.' : null,
+    hasDiffStat ? '- \`diff-stat.txt\`: A summary of the changed files and lines.' : null,
+    '- \`pr-meta.md\`: The PR title and description.',
+    '- \`comments.md\`: The full comment history of the PR.',
+  ].filter(Boolean).join('\n');
   writeFileSync(join(contextDir, 'README.md'), manifest);
 
   const systemPrompt = buildSystemPrompt(incremental);


### PR DESCRIPTION
The full diff should be provided (in a separate file) in case the reviewer needs to look at all the changes made by this PR. 

Currently, only the most recent diff is provided.