### PR TITLE
PBI re-derivation diffing and human acceptance flow (#86)

### DIFF
--- a/src/db/pbiStore.ts
+++ b/src/db/pbiStore.ts
@@ -46,6 +46,10 @@ export function getPbisForSpec(specId: string): PbiRecord[] {
   return db.prepare('SELECT * FROM pbis WHERE specId = ? ORDER BY createdAt ASC').all(specId) as PbiRecord[];
 }
 
+export function deletePbi(pbiId: string): void {
+  db.prepare('DELETE FROM pbis WHERE pbiId = ?').run(pbiId);
+}
+
 export function deletePbisForSpec(specId: string): void {
   db.prepare('DELETE FROM pbis WHERE specId = ?').run(specId);
 }

--- a/src/gates/pbiAcceptance.ts
+++ b/src/gates/pbiAcceptance.ts
@@ -1,0 +1,104 @@
+import crypto from 'crypto';
+import { PbiRecord, savePbi, deletePbi } from '../db/pbiStore';
+import { DerivedPbi } from './pbiDerivation';
+import { computePbiDiff, PbiDiff } from '../utils/pbiDiff';
+
+export interface AcceptPbiDiffResult {
+  readonly diff: PbiDiff;
+  readonly created: readonly PbiRecord[];
+  readonly updated: readonly PbiRecord[];
+  readonly removed: readonly PbiRecord['pbiId'][];
+  readonly skippedRemovals: readonly PbiDiff['removals'][number][];
+}
+
+export class BlockingRemovalError extends Error {
+  constructor(public readonly diff: PbiDiff) {
+    super(
+      `Cannot accept this derivation: ${diff.removals.filter((r) => r.statusIncompatible).length} PBI(s) with in-progress/done work would be removed. Resolve these manually (e.g. re-derive with adjusted spec, or explicitly override) before accepting.`
+    );
+    this.name = 'BlockingRemovalError';
+  }
+}
+
+/**
+ * Persists an accepted PBI-derivation (or re-derivation diff) for a spec,
+ * per RM-REQ-073. PBIs are not ephemeral / recomputed-on-read: this is the
+ * only path by which a derivation's output is written to the database, and
+ * it only runs once a human has reviewed and accepted the proposed diff
+ * (computed via computePbiDiff / the /api/copilot/pbi-diff endpoint).
+ *
+ * By default, a diff containing a status-incompatible removal (an existing
+ * 'in_progress' or 'done' PBI that the new derivation no longer contains)
+ * is rejected outright (RM-REQ-072) -- pass `allowStatusIncompatibleRemovals:
+ * true` to explicitly override and remove them anyway.
+ */
+export function acceptPbiDiff(
+  specId: string,
+  existing: readonly PbiRecord[],
+  derived: readonly DerivedPbi[],
+  options: { allowStatusIncompatibleRemovals?: boolean } = {}
+): AcceptPbiDiffResult {
+  const diff = computePbiDiff(specId, existing, derived);
+
+  if (diff.hasBlockingRemovals && !options.allowStatusIncompatibleRemovals) {
+    throw new BlockingRemovalError(diff);
+  }
+
+  const now = Date.now();
+
+  // Resolve batchId -> pbiId for newly-created additions before persisting,
+  // so that dependsOn edges between two additions in the same batch resolve
+  // to real pbiIds rather than batch-local placeholders.
+  const batchIdToNewPbiId = new Map<string, string>();
+  for (const addition of diff.additions) {
+    batchIdToNewPbiId.set(addition.batchId, `${specId}-pbi-${crypto.randomUUID()}`);
+  }
+
+  function resolveFinal(id: string): string {
+    return batchIdToNewPbiId.get(id) ?? id;
+  }
+
+  const created: PbiRecord[] = [];
+  for (const addition of diff.additions) {
+    const record: PbiRecord = {
+      pbiId: batchIdToNewPbiId.get(addition.batchId)!,
+      specId,
+      title: addition.title,
+      description: addition.description,
+      status: addition.status,
+      dependsOn: JSON.stringify(addition.dependsOn.map(resolveFinal)),
+      createdAt: now,
+      updatedAt: now,
+    };
+    savePbi(record);
+    created.push(record);
+  }
+
+  const existingById = new Map(existing.map((p) => [p.pbiId, p]));
+  const updated: PbiRecord[] = [];
+  for (const change of diff.edgeChanges) {
+    const prior = existingById.get(change.pbiId);
+    if (!prior) continue;
+    const record: PbiRecord = {
+      ...prior,
+      dependsOn: JSON.stringify(change.newDependsOn.map(resolveFinal)),
+      updatedAt: now,
+    };
+    savePbi(record);
+    updated.push(record);
+  }
+
+  const removed: string[] = [];
+  const skippedRemovals: PbiDiff['removals'][number][] = [];
+  for (const removal of diff.removals) {
+    if (removal.statusIncompatible && !options.allowStatusIncompatibleRemovals) {
+      // Should be unreachable given the guard above, but kept defensive.
+      skippedRemovals.push(removal);
+      continue;
+    }
+    deletePbi(removal.pbiId);
+    removed.push(removal.pbiId);
+  }
+
+  return { diff, created, updated, removed, skippedRemovals };
+}

--- a/src/serverRuntime.ts
+++ b/src/serverRuntime.ts
@@ -74,7 +74,10 @@ import { makeDockerToolHandler } from './utils/toolHandlers';
 import { RUN_TERMINAL_DOCKER_TOOL, submitAuditFindingsTool, COMPOSER_ROUTER_TOOL, AMBIGUITY_CHECK_TOOL } from './config/tools';
 import { normalizeGates, TASK_TYPE_GATE_MAP, resolvePipeline } from './config/gates';
 import { runSpecAudit } from './gates/specAuditor';
-import { runPbiDerivation } from './gates/pbiDerivation';
+import { runPbiDerivation, DerivedPbi } from './gates/pbiDerivation';
+import { computePbiDiff } from './utils/pbiDiff';
+import { acceptPbiDiff, BlockingRemovalError } from './gates/pbiAcceptance';
+import { getPbisForSpec } from './db/pbiStore';
 import { sanitizeSensitives } from './utils/sanitizers';
 import { truncateOutput } from './utils/formatters';
 import { initializeWorkspace, getGitSandbox, getExecCommand, getWorkspaceHostLocation, getWorkspaceRoot } from './workspace';
@@ -1397,6 +1400,66 @@ export function setActiveOpenRouterSessionId(sessionId: string | undefined) {
       res.json({ success: true, specId: result.specId, pbis: result.pbis });
     } catch (err: unknown) {
       writeLog(`[PbiDerivation] Derivation failed for specId ${specId}: ${err instanceof Error ? err.message : String(err)}`);
+      res.status(500).json({ success: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  // Diff a proposed derivation batch against the persisted PBI set for a
+  // spec (RM-REQ-072). Read-only -- does not persist anything. This is the
+  // step a human reviews before calling /api/copilot/pbi-accept.
+  app.post('/api/copilot/pbi-diff', (req, res) => {
+    const { specId, pbis } = req.body;
+
+    if (!specId || typeof specId !== 'string') {
+      res.status(400).json({ success: false, error: 'specId is required.' });
+      return;
+    }
+    if (!Array.isArray(pbis)) {
+      res.status(400).json({ success: false, error: 'pbis (array) is required.' });
+      return;
+    }
+
+    try {
+      const existing = getPbisForSpec(specId);
+      const diff = computePbiDiff(specId, existing, pbis as DerivedPbi[]);
+      res.json({ success: true, diff });
+    } catch (err: unknown) {
+      res.status(500).json({ success: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  // Persist an accepted derivation/re-derivation diff (RM-REQ-073). Requires
+  // the human to have reviewed the /api/copilot/pbi-diff output first; PBIs
+  // are never persisted automatically by the derivation step itself.
+  app.post('/api/copilot/pbi-accept', (req, res) => {
+    const { specId, pbis, allowStatusIncompatibleRemovals } = req.body;
+
+    if (!specId || typeof specId !== 'string') {
+      res.status(400).json({ success: false, error: 'specId is required.' });
+      return;
+    }
+    if (!Array.isArray(pbis)) {
+      res.status(400).json({ success: false, error: 'pbis (array) is required.' });
+      return;
+    }
+
+    try {
+      const existing = getPbisForSpec(specId);
+      const result = acceptPbiDiff(specId, existing, pbis as DerivedPbi[], {
+        allowStatusIncompatibleRemovals: Boolean(allowStatusIncompatibleRemovals),
+      });
+      res.json({
+        success: true,
+        created: result.created,
+        updated: result.updated,
+        removed: result.removed,
+        skippedRemovals: result.skippedRemovals,
+      });
+    } catch (err: unknown) {
+      if (err instanceof BlockingRemovalError) {
+        res.status(409).json({ success: false, error: err.message, diff: err.diff });
+        return;
+      }
       res.status(500).json({ success: false, error: err instanceof Error ? err.message : String(err) });
     }
   });

--- a/src/test/pbi_diff_and_acceptance.test.ts
+++ b/src/test/pbi_diff_and_acceptance.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import { db } from '../db/index';
+import { saveSpec } from '../db/taskStore';
+import { savePbi, getPbisForSpec, PbiRecord } from '../db/pbiStore';
+import { computePbiDiff } from '../utils/pbiDiff';
+import { acceptPbiDiff, BlockingRemovalError } from '../gates/pbiAcceptance';
+import { DerivedPbi } from '../gates/pbiDerivation';
+
+function pbi(overrides: Partial<PbiRecord> & { pbiId: string; title: string }): PbiRecord {
+  return {
+    specId: 'spec-1',
+    description: null,
+    status: 'pending',
+    dependsOn: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function derived(overrides: Partial<DerivedPbi> & { batchId: string; title: string }): DerivedPbi {
+  return {
+    description: 'desc',
+    status: 'pending',
+    dependsOn: [],
+    ...overrides,
+  };
+}
+
+describe('computePbiDiff', () => {
+  it('treats everything as an addition when nothing is persisted yet', () => {
+    const diff = computePbiDiff('spec-1', [], [
+      derived({ batchId: 'pbi-1', title: 'Scaffolding' }),
+      derived({ batchId: 'pbi-2', title: 'Wire it up', dependsOn: ['pbi-1'] }),
+    ]);
+
+    expect(diff.additions).toHaveLength(2);
+    expect(diff.removals).toHaveLength(0);
+    expect(diff.edgeChanges).toHaveLength(0);
+    expect(diff.unchanged).toHaveLength(0);
+    const wireUp = diff.additions.find((a) => a.title === 'Wire it up')!;
+    expect(wireUp.dependsOn).toEqual(['pbi-1']); // dangling batchId ref, resolved at accept time
+  });
+
+  it('matches existing PBIs by normalized title and reports unchanged when edges match', () => {
+    const existing = [pbi({ pbiId: 'pbi-a', title: '  Scaffolding  ', dependsOn: JSON.stringify([]) })];
+    const diff = computePbiDiff('spec-1', existing, [derived({ batchId: 'pbi-1', title: 'scaffolding' })]);
+
+    expect(diff.unchanged).toEqual([{ pbiId: 'pbi-a', title: '  Scaffolding  ' }]);
+    expect(diff.additions).toHaveLength(0);
+    expect(diff.edgeChanges).toHaveLength(0);
+  });
+
+  it('reports an edge change when dependsOn differs for a matched PBI', () => {
+    const existing = [
+      pbi({ pbiId: 'pbi-a', title: 'Scaffolding' }),
+      pbi({ pbiId: 'pbi-b', title: 'Wire it up', dependsOn: JSON.stringify([]) }),
+    ];
+    const diff = computePbiDiff('spec-1', existing, [
+      derived({ batchId: 'd1', title: 'Scaffolding' }),
+      derived({ batchId: 'd2', title: 'Wire it up', dependsOn: ['d1'] }),
+    ]);
+
+    expect(diff.edgeChanges).toEqual([
+      { pbiId: 'pbi-b', title: 'Wire it up', oldDependsOn: [], newDependsOn: ['pbi-a'] },
+    ]);
+  });
+
+  it('flags a safe removal (pending) as non-blocking and an in-progress removal as status-incompatible', () => {
+    const existing = [
+      pbi({ pbiId: 'pbi-safe', title: 'Stale idea', status: 'pending' }),
+      pbi({ pbiId: 'pbi-unsafe', title: 'Real work', status: 'in_progress' }),
+    ];
+    const diff = computePbiDiff('spec-1', existing, []);
+
+    expect(diff.removals).toHaveLength(2);
+    const safe = diff.removals.find((r) => r.pbiId === 'pbi-safe')!;
+    const unsafe = diff.removals.find((r) => r.pbiId === 'pbi-unsafe')!;
+    expect(safe.statusIncompatible).toBe(false);
+    expect(unsafe.statusIncompatible).toBe(true);
+    expect(diff.hasBlockingRemovals).toBe(true);
+  });
+});
+
+describe('acceptPbiDiff (persistence)', () => {
+  beforeEach(() => {
+    db.prepare('DELETE FROM tasks').run();
+    db.prepare('DELETE FROM pbis').run();
+    db.prepare('DELETE FROM specs').run();
+    saveSpec({ specId: 'spec-accept-1', filePath: 'spec.md', version: 'v1', createdAt: Date.now() });
+  });
+
+  it('persists additions and resolves intra-batch dependsOn to real pbiIds', () => {
+    const result = acceptPbiDiff('spec-accept-1', [], [
+      derived({ batchId: 'pbi-1', title: 'Scaffolding' }),
+      derived({ batchId: 'pbi-2', title: 'Wire it up', dependsOn: ['pbi-1'] }),
+    ]);
+
+    expect(result.created).toHaveLength(2);
+    const persisted = getPbisForSpec('spec-accept-1');
+    expect(persisted).toHaveLength(2);
+
+    const wireUp = persisted.find((p) => p.title === 'Wire it up')!;
+    const scaffolding = persisted.find((p) => p.title === 'Scaffolding')!;
+    expect(JSON.parse(wireUp.dependsOn!)).toEqual([scaffolding.pbiId]);
+    expect(scaffolding.pbiId).not.toBe('pbi-1'); // batchId is not the persisted id
+  });
+
+  it('is idempotent on immediate re-derivation with no changes (nothing created/updated/removed)', () => {
+    acceptPbiDiff('spec-accept-1', [], [derived({ batchId: 'pbi-1', title: 'Scaffolding' })]);
+    const existing = getPbisForSpec('spec-accept-1');
+
+    const result = acceptPbiDiff('spec-accept-1', existing, [derived({ batchId: 'd1', title: 'Scaffolding' })]);
+
+    expect(result.created).toHaveLength(0);
+    expect(result.updated).toHaveLength(0);
+    expect(result.removed).toHaveLength(0);
+    expect(getPbisForSpec('spec-accept-1')).toHaveLength(1);
+  });
+
+  it('rejects (does not persist) a diff with a status-incompatible removal unless explicitly overridden', () => {
+    savePbi(pbi({ pbiId: 'pbi-inprog', specId: 'spec-accept-1', title: 'Real work', status: 'in_progress' }));
+
+    expect(() => acceptPbiDiff('spec-accept-1', getPbisForSpec('spec-accept-1'), [])).toThrow(BlockingRemovalError);
+    expect(getPbisForSpec('spec-accept-1')).toHaveLength(1); // untouched
+
+    const result = acceptPbiDiff('spec-accept-1', getPbisForSpec('spec-accept-1'), [], {
+      allowStatusIncompatibleRemovals: true,
+    });
+    expect(result.removed).toEqual(['pbi-inprog']);
+    expect(getPbisForSpec('spec-accept-1')).toHaveLength(0);
+  });
+
+  it('removes safe (pending/blocked) PBIs without requiring an override', () => {
+    savePbi(pbi({ pbiId: 'pbi-stale', specId: 'spec-accept-1', title: 'Stale idea', status: 'pending' }));
+
+    const result = acceptPbiDiff('spec-accept-1', getPbisForSpec('spec-accept-1'), []);
+    expect(result.removed).toEqual(['pbi-stale']);
+    expect(getPbisForSpec('spec-accept-1')).toHaveLength(0);
+  });
+});

--- a/src/utils/pbiDiff.ts
+++ b/src/utils/pbiDiff.ts
@@ -1,0 +1,155 @@
+import { PbiRecord } from '../db/pbiStore';
+import { DerivedPbi } from '../gates/pbiDerivation';
+
+/**
+ * Statuses under which removing a persisted PBI is considered safe: no work
+ * has started, or the PBI was already known to be blocked. Anything further
+ * along ('in_progress' | 'done') represents real completed/ongoing work, so
+ * a re-derivation that no longer contains that PBI cannot silently drop it
+ * (RM-REQ-072).
+ */
+const REMOVAL_SAFE_STATUSES: ReadonlySet<PbiRecord['status']> = new Set(['pending', 'blocked']);
+
+/**
+ * Normalizes a title for identity matching between an existing persisted PBI
+ * and a freshly derived one. Derivation has no notion of persisted pbiIds
+ * (it only knows batch-local batchIds), so title is the only stable-ish
+ * signal available for matching without a dedicated matching model pass
+ * (flagged as an open/unsolved Groomer-role problem in the roadmap spec --
+ * this is intentionally a simple heuristic, not a claim of semantic matching).
+ */
+function normalizeTitle(title: string): string {
+  return title.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+export interface PbiAddition {
+  readonly batchId: string;
+  readonly title: string;
+  readonly description: string;
+  readonly status: DerivedPbi['status'];
+  /** dependsOn expressed as batchIds, resolved to pbiIds/batchIds at accept time. */
+  readonly dependsOn: readonly string[];
+}
+
+export interface PbiEdgeChange {
+  readonly pbiId: string;
+  readonly title: string;
+  readonly oldDependsOn: readonly string[];
+  readonly newDependsOn: readonly string[];
+}
+
+export interface PbiRemoval {
+  readonly pbiId: string;
+  readonly title: string;
+  readonly status: PbiRecord['status'];
+  /** True if this PBI has status 'in_progress' or 'done' -- removal is blocked until manually resolved. */
+  readonly statusIncompatible: boolean;
+}
+
+export interface PbiUnchanged {
+  readonly pbiId: string;
+  readonly title: string;
+}
+
+export interface PbiDiff {
+  readonly specId: string;
+  readonly additions: readonly PbiAddition[];
+  readonly edgeChanges: readonly PbiEdgeChange[];
+  readonly removals: readonly PbiRemoval[];
+  readonly unchanged: readonly PbiUnchanged[];
+  /** True if any removal is status-incompatible; acceptance of this diff as-is is blocked until resolved. */
+  readonly hasBlockingRemovals: boolean;
+}
+
+/**
+ * Computes a proposed diff between the PBIs currently persisted for a spec
+ * and a freshly derived batch, per RM-REQ-072. Matching between the two sets
+ * is by normalized title (see normalizeTitle) since derivation output has no
+ * persisted pbiId to key off of.
+ *
+ * This is pure and read-only -- it does not touch the database.
+ */
+export function computePbiDiff(specId: string, existing: readonly PbiRecord[], derived: readonly DerivedPbi[]): PbiDiff {
+  const existingByTitle = new Map<string, PbiRecord>();
+  for (const pbi of existing) {
+    existingByTitle.set(normalizeTitle(pbi.title), pbi);
+  }
+
+  const derivedByBatchId = new Map<string, DerivedPbi>();
+  for (const d of derived) {
+    derivedByBatchId.set(d.batchId, d);
+  }
+
+  // Resolve a derived PBI's dependsOn (batchIds) into pbiIds where the
+  // target batchId matches an existing persisted PBI by title, else leave
+  // as the batchId itself (resolved to a real pbiId only once that addition
+  // is persisted, at accept time).
+  function resolveDependsOn(dependsOn: readonly string[]): string[] {
+    return dependsOn.map((batchId) => {
+      const target = derivedByBatchId.get(batchId);
+      if (!target) return batchId; // dangling reference; passed through as-is
+      const matched = existingByTitle.get(normalizeTitle(target.title));
+      return matched ? matched.pbiId : batchId;
+    });
+  }
+
+  const additions: PbiAddition[] = [];
+  const edgeChanges: PbiEdgeChange[] = [];
+  const unchanged: PbiUnchanged[] = [];
+  const matchedExistingTitles = new Set<string>();
+
+  for (const d of derived) {
+    const normalized = normalizeTitle(d.title);
+    const existingMatch = existingByTitle.get(normalized);
+
+    if (!existingMatch) {
+      additions.push({
+        batchId: d.batchId,
+        title: d.title,
+        description: d.description,
+        status: d.status,
+        dependsOn: resolveDependsOn(d.dependsOn),
+      });
+      continue;
+    }
+
+    matchedExistingTitles.add(normalized);
+    const oldDependsOn: string[] = existingMatch.dependsOn ? JSON.parse(existingMatch.dependsOn) : [];
+    const newDependsOn = resolveDependsOn(d.dependsOn);
+
+    const oldSet = new Set(oldDependsOn);
+    const newSet = new Set(newDependsOn);
+    const edgesEqual = oldSet.size === newSet.size && [...oldSet].every((id) => newSet.has(id));
+
+    if (edgesEqual) {
+      unchanged.push({ pbiId: existingMatch.pbiId, title: existingMatch.title });
+    } else {
+      edgeChanges.push({
+        pbiId: existingMatch.pbiId,
+        title: existingMatch.title,
+        oldDependsOn,
+        newDependsOn,
+      });
+    }
+  }
+
+  const removals: PbiRemoval[] = [];
+  for (const pbi of existing) {
+    if (matchedExistingTitles.has(normalizeTitle(pbi.title))) continue;
+    removals.push({
+      pbiId: pbi.pbiId,
+      title: pbi.title,
+      status: pbi.status,
+      statusIncompatible: !REMOVAL_SAFE_STATUSES.has(pbi.status),
+    });
+  }
+
+  return {
+    specId,
+    additions,
+    edgeChanges,
+    removals,
+    unchanged,
+    hasBlockingRemovals: removals.some((r) => r.statusIncompatible),
+  };
+}


### PR DESCRIPTION
RM-REQ-072 / RM-REQ-073.

- src/utils/pbiDiff.ts: computePbiDiff(specId, existing, derived) -- pure, read-only diff between the persisted PBI set and a freshly derived batch. Matches by normalized title (derivation output has no persisted pbiId to key off of; semantic matching is flagged as an open Groomer-role problem in the roadmap spec, not attempted here). Produces additions, edgeChanges (dependsOn diffs on matched PBIs), removals (flagged statusIncompatible when status is in_progress/done), and unchanged.

- src/gates/pbiAcceptance.ts: acceptPbiDiff(specId, existing, derived, options) -- the only path that persists derived PBIs (RM-REQ-073, not ephemeral/recomputed-on-read). Recomputes the diff, generates real pbiIds for additions, resolves intra-batch dependsOn edges (batchId -> pbiId), updates edges for matched PBIs, and deletes safe removals. Throws BlockingRemovalError if the diff has a status-incompatible removal unless allowStatusIncompatibleRemovals is explicitly passed.

- src/db/pbiStore.ts: added deletePbi(pbiId).

- serverRuntime.ts: two new endpoints --
    POST /api/copilot/pbi-diff   (read-only, human review step)
    POST /api/copilot/pbi-accept (persists an accepted diff; 409 +
                                   BlockingRemovalError diff payload if
                                   blocked)

- Tests: src/test/pbi_diff_and_acceptance.test.ts -- diff matching/edge changes/removal classification, additions persistence with resolved dependsOn, idempotent re-derivation with no changes, blocked vs. override removal of in-progress work, and safe removal of pending/blocked PBIs.



---


