### PR TITLE
Pbi derivation issue 89

### DIFF
--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -103,6 +103,52 @@ export const submitSpecAuditTool = {
   }
 };
 
+export const submitPbiDerivationTool = {
+  type: 'function',
+  function: {
+    name: "submit_pbi_derivation",
+    description: "Submit the derived set of Product Backlog Items (PBIs) for a spec, including intra-batch dependency edges. This is a proposed set only -- nothing is persisted by this call.",
+    parameters: {
+      type: "object",
+      properties: {
+        pbis: {
+          type: "array",
+          description: "The proposed PBIs derived from the spec, in dependency-friendly order (a PBI should generally not depend on a PBI listed after it, though this is not strictly enforced).",
+          items: {
+            type: "object",
+            properties: {
+              batchId: {
+                type: "string",
+                description: "A short identifier unique within this batch (e.g. 'pbi-1'), used only to express dependsOn edges below. This is NOT a persisted database ID -- real pbiIds are assigned when the batch is accepted and persisted."
+              },
+              title: {
+                type: "string",
+                description: "Short, human-readable title for the PBI."
+              },
+              description: {
+                type: "string",
+                description: "A clear description of the scope and boundaries of this PBI."
+              },
+              status: {
+                type: "string",
+                enum: ["pending", "in_progress", "blocked", "done"],
+                description: "Initial status for a freshly derived PBI. Should almost always be 'pending' unless there is clear evidence in the repository that work has already started or finished."
+              },
+              dependsOn: {
+                type: "array",
+                items: { type: "string" },
+                description: "List of batchId values (from this same batch only) that this PBI depends on. Empty array if none."
+              }
+            },
+            required: ["batchId", "title", "description", "status", "dependsOn"]
+          }
+        }
+      },
+      required: ["pbis"]
+    }
+  }
+};
+
 export const submitCodeReviewTool = {
   type: 'function',
   function: {

--- a/src/gates/pbiDerivation.ts
+++ b/src/gates/pbiDerivation.ts
@@ -1,0 +1,112 @@
+import { getAuditorExecutionConfig, executeAuditSession } from '../utils/auditorHelper';
+import { submitPbiDerivationTool } from '../config/tools';
+import { getExecCommand, getWorkspaceRoot } from '../workspace';
+import { getSpec } from '../db/taskStore';
+import path from 'path';
+
+/**
+ * A single PBI as proposed by the derivation operation. `batchId` is a
+ * batch-local identifier used only to express `dependsOn` edges within the
+ * same derivation call -- it is not a persisted database `pbiId`. Real
+ * `pbiId`s are assigned when a batch (or diff against an existing batch) is
+ * accepted and persisted (see Issue 4).
+ */
+export interface DerivedPbi {
+  readonly batchId: string;
+  readonly title: string;
+  readonly description: string;
+  readonly status: 'pending' | 'in_progress' | 'blocked' | 'done';
+  readonly dependsOn: readonly string[];
+}
+
+interface PbiDerivationToolResult {
+  pbis: DerivedPbi[];
+}
+
+export interface PbiDerivationResult {
+  readonly specId: string;
+  readonly pbis: DerivedPbi[];
+}
+
+const SUBMIT_PBI_DERIVATION_EXAMPLE = `{
+  "pbis": [
+    { "batchId": "pbi-1", "title": "Set up auth scaffolding", "description": "Add the auth module skeleton, config, and empty middleware.", "status": "pending", "dependsOn": [] },
+    { "batchId": "pbi-2", "title": "Wire login flow", "description": "Implement the login endpoint and session issuance on top of the scaffolding.", "status": "pending", "dependsOn": ["pbi-1"] }
+  ]
+}`;
+
+const SYSTEM_PROMPT = `You are a PBI (Product Backlog Item) derivation agent. Given a specification document and the current repository state, break the spec down into a set of PBIs -- coherent, independently workable units of work larger than a single task but smaller than the whole spec.
+
+**Boundary rules:**
+- PBI boundaries are derived from the spec's actual functional seams, not from its document structure -- a single markdown section or requirement may span multiple PBIs, and a single PBI may draw from multiple sections.
+- Prefer PBIs that can be worked and verified independently once their dependencies are done.
+- Do not over-fragment: a PBI that would only ever contain a single trivial task is usually too small.
+
+**Dependency rules:**
+- Only express a \`dependsOn\` edge when one PBI's work genuinely cannot begin (or cannot be verified) until another completes.
+- \`dependsOn\` values must reference \`batchId\`s from this same batch only.
+- Do not create dependency cycles.
+
+You must not answer conversationally and must strictly invoke 'submit_pbi_derivation'.
+
+**How to call the tool:**
+Call 'submit_pbi_derivation' using your tool-calling capability (a real function/tool call), not as text in your message. Example of correctly-shaped arguments:
+
+${SUBMIT_PBI_DERIVATION_EXAMPLE}`;
+
+function buildUserPrompt(specContent: string): string {
+  return `Derive the set of PBIs for the following specification.
+
+SPEC:
+${specContent}`;
+}
+
+/**
+ * Human-initiated PBI-derivation operation (RM-REQ-070). Analyzes the spec
+ * identified by `specId` together with the current repository state and
+ * produces a proposed set of PBIs via a forced tool call, following the same
+ * discipline as the Spec-Gate Auditor and PR Reviewer.
+ *
+ * This does NOT persist anything -- the returned set is a proposal. Diffing
+ * against any already-persisted PBIs for this spec, and persistence on
+ * acceptance, are handled by a later operation (Issue 4 / RM-REQ-072/073).
+ */
+export async function runPbiDerivation(
+  cwd: string,
+  specId: string,
+  abortSignal?: AbortSignal
+): Promise<PbiDerivationResult> {
+  const specRecord = getSpec(specId);
+  if (!specRecord) {
+    throw new Error(`No spec found for specId "${specId}".`);
+  }
+
+  const absoluteSpecPath = path.isAbsolute(specRecord.filePath)
+    ? specRecord.filePath
+    : path.join(getWorkspaceRoot(), specRecord.filePath);
+
+  const execResult = await getExecCommand()(`cat '${absoluteSpecPath}'`, abortSignal);
+  if (execResult.exitCode !== 0) {
+    throw new Error(`Failed to read spec file for specId "${specId}" at ${specRecord.filePath}: ${execResult.stderr}`);
+  }
+  const specContent = execResult.stdout;
+
+  const executionConfig = getAuditorExecutionConfig();
+  const userPrompt = buildUserPrompt(specContent);
+
+  const result = await executeAuditSession<PbiDerivationToolResult>(
+    cwd,
+    executionConfig,
+    SYSTEM_PROMPT,
+    submitPbiDerivationTool,
+    userPrompt,
+    { toolCallExample: SUBMIT_PBI_DERIVATION_EXAMPLE },
+    abortSignal
+  );
+
+  if (!result || !Array.isArray(result.pbis)) {
+    throw new Error('PBI derivation failed: model did not return a proper submit_pbi_derivation tool call.');
+  }
+
+  return { specId, pbis: result.pbis };
+}

--- a/src/serverRuntime.ts
+++ b/src/serverRuntime.ts
@@ -74,6 +74,7 @@ import { makeDockerToolHandler } from './utils/toolHandlers';
 import { RUN_TERMINAL_DOCKER_TOOL, submitAuditFindingsTool, COMPOSER_ROUTER_TOOL, AMBIGUITY_CHECK_TOOL } from './config/tools';
 import { normalizeGates, TASK_TYPE_GATE_MAP, resolvePipeline } from './config/gates';
 import { runSpecAudit } from './gates/specAuditor';
+import { runPbiDerivation } from './gates/pbiDerivation';
 import { sanitizeSensitives } from './utils/sanitizers';
 import { truncateOutput } from './utils/formatters';
 import { initializeWorkspace, getGitSandbox, getExecCommand, getWorkspaceHostLocation, getWorkspaceRoot } from './workspace';
@@ -1364,6 +1365,37 @@ export function setActiveOpenRouterSessionId(sessionId: string | undefined) {
 
     // 3. Inform client
     res.json({ success: true, message: 'Spec patched successfully.' });
+  });
+
+  // PBI-derivation trigger (RM-REQ-070/071). Human-initiated: analyzes the
+  // spec identified by specId and returns a proposed set of PBIs via a
+  // forced tool call. Nothing is persisted by this endpoint -- accepting a
+  // derivation and persisting it is a separate, later operation (Issue 4).
+  app.post('/api/copilot/pbi-derivation', async (req, res) => {
+    const { specId, cwd } = req.body;
+
+    if (!specId || typeof specId !== 'string') {
+      res.status(400).json({ success: false, error: 'specId is required.' });
+      return;
+    }
+
+    let targetCwd: string;
+    try {
+      targetCwd = validateCwd(cwd || getWorkspaceRoot());
+    } catch (err: unknown) {
+      res.status(400).json({ success: false, error: `Invalid cwd: ${err instanceof Error ? err.message : String(err)}` });
+      return;
+    }
+
+    writeLog(`[PbiDerivation] Received derivation request for specId: ${specId}`);
+
+    try {
+      const result = await runPbiDerivation(targetCwd, specId);
+      res.json({ success: true, specId: result.specId, pbis: result.pbis });
+    } catch (err: unknown) {
+      writeLog(`[PbiDerivation] Derivation failed for specId ${specId}: ${err instanceof Error ? err.message : String(err)}`);
+      res.status(500).json({ success: false, error: err instanceof Error ? err.message : String(err) });
+    }
   });
 
   // RESTful Panic Stop Route (SYS-REQ-017/018)

--- a/src/serverRuntime.ts
+++ b/src/serverRuntime.ts
@@ -1389,8 +1389,11 @@ export function setActiveOpenRouterSessionId(sessionId: string | undefined) {
 
     writeLog(`[PbiDerivation] Received derivation request for specId: ${specId}`);
 
+    const controller = new AbortController();
+    req.on('close', () => controller.abort());
+
     try {
-      const result = await runPbiDerivation(targetCwd, specId);
+      const result = await runPbiDerivation(targetCwd, specId, controller.signal);
       res.json({ success: true, specId: result.specId, pbis: result.pbis });
     } catch (err: unknown) {
       writeLog(`[PbiDerivation] Derivation failed for specId ${specId}: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/test/pbi_derivation.test.ts
+++ b/src/test/pbi_derivation.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import * as path from 'path';
+import * as fs from 'fs';
+import { db } from '../db/index';
+import { saveSpec } from '../db/taskStore';
+import { getWorkspaceRoot } from '../workspace';
+
+vi.mock('../utils/auditorHelper', async () => {
+  const actual = await vi.importActual<typeof import('../utils/auditorHelper')>('../utils/auditorHelper');
+  return {
+    ...actual,
+    getAuditorExecutionConfig: () => ({ model: 'mock-model', provider: undefined }),
+    executeAuditSession: vi.fn(),
+  };
+});
+
+import { executeAuditSession } from '../utils/auditorHelper';
+import { runPbiDerivation } from '../gates/pbiDerivation';
+
+const mockedExecuteAuditSession = executeAuditSession as unknown as ReturnType<typeof vi.fn>;
+
+describe('PBI derivation operation', () => {
+  const mockCwd = path.join(getWorkspaceRoot(), 'test-pbi-derivation-dir');
+
+  beforeEach(() => {
+    db.prepare('DELETE FROM tasks').run();
+    db.prepare('DELETE FROM pbis').run();
+    db.prepare('DELETE FROM specs').run();
+    mockedExecuteAuditSession.mockReset();
+    if (!fs.existsSync(mockCwd)) {
+      fs.mkdirSync(mockCwd, { recursive: true });
+    }
+    fs.writeFileSync(path.join(mockCwd, 'architecture-spec.md'), 'Spec: build a widget.');
+  });
+
+  it('throws when the specId does not exist', async () => {
+    await expect(runPbiDerivation(mockCwd, 'spec-does-not-exist')).rejects.toThrow(/No spec found/);
+    expect(mockedExecuteAuditSession).not.toHaveBeenCalled();
+  });
+
+  it('returns the proposed PBI batch (not persisted) on a successful tool call', async () => {
+    const relativePath = path.relative(getWorkspaceRoot(), path.join(mockCwd, 'architecture-spec.md'));
+    saveSpec({ specId: 'spec-widget-1', filePath: relativePath, version: 'v1', createdAt: Date.now() });
+
+    mockedExecuteAuditSession.mockResolvedValue({
+      pbis: [
+        { batchId: 'pbi-1', title: 'Scaffolding', description: 'Set up the widget module.', status: 'pending', dependsOn: [] },
+        { batchId: 'pbi-2', title: 'Wire it up', description: 'Connect the widget to the app.', status: 'pending', dependsOn: ['pbi-1'] },
+      ],
+    });
+
+    const result = await runPbiDerivation(mockCwd, 'spec-widget-1');
+
+    expect(result.specId).toBe('spec-widget-1');
+    expect(result.pbis).toHaveLength(2);
+    expect(result.pbis[1]?.dependsOn).toEqual(['pbi-1']);
+
+    // Not persisted -- this is a proposal only (Issue 4 handles persistence).
+    const persisted = db.prepare('SELECT * FROM pbis WHERE specId = ?').all('spec-widget-1');
+    expect(persisted).toHaveLength(0);
+
+    // Confirms the forced-tool-call discipline: submit_pbi_derivation is the
+    // only tool passed through to the session (mirrors the Auditor/Reviewer pattern).
+    const [, , , tool] = mockedExecuteAuditSession.mock.calls[0] as unknown[];
+    expect((tool as { function: { name: string } }).function.name).toBe('submit_pbi_derivation');
+  });
+
+  it('throws when the model never returns a valid tool call', async () => {
+    const relativePath = path.relative(getWorkspaceRoot(), path.join(mockCwd, 'architecture-spec.md'));
+    saveSpec({ specId: 'spec-widget-2', filePath: relativePath, version: 'v1', createdAt: Date.now() });
+    mockedExecuteAuditSession.mockResolvedValue(null);
+
+    await expect(runPbiDerivation(mockCwd, 'spec-widget-2')).rejects.toThrow(/did not return a proper submit_pbi_derivation/);
+  });
+});


### PR DESCRIPTION
RM-REQ-072 / RM-REQ-073.

- src/utils/pbiDiff.ts: computePbiDiff(specId, existing, derived) -- pure, read-only diff between the persisted PBI set and a freshly derived batch. Matches by normalized title (derivation output has no persisted pbiId to key off of; semantic matching is flagged as an open Groomer-role problem in the roadmap spec, not attempted here). Produces additions, edgeChanges (dependsOn diffs on matched PBIs), removals (flagged statusIncompatible when status is in_progress/done), and unchanged.

- src/gates/pbiAcceptance.ts: acceptPbiDiff(specId, existing, derived, options) -- the only path that persists derived PBIs (RM-REQ-073, not ephemeral/recomputed-on-read). Recomputes the diff, generates real pbiIds for additions, resolves intra-batch dependsOn edges (batchId -> pbiId), updates edges for matched PBIs, and deletes safe removals. Throws BlockingRemovalError if the diff has a status-incompatible removal unless allowStatusIncompatibleRemovals is explicitly passed.

- src/db/pbiStore.ts: added deletePbi(pbiId).

- serverRuntime.ts: two new endpoints --
    POST /api/copilot/pbi-diff   (read-only, human review step)
    POST /api/copilot/pbi-accept (persists an accepted diff; 409 +
                                   BlockingRemovalError diff payload if
                                   blocked)

- Tests: src/test/pbi_diff_and_acceptance.test.ts -- diff matching/edge changes/removal classification, additions persistence with resolved dependsOn, idempotent re-derivation with no changes, blocked vs. override removal of in-progress work, and safe removal of pending/blocked PBIs.






---



## Overview
Implement a diffing mechanism and human acceptance flow for PBI re-derivation. When derivation runs against a `specId` that already has persisted PBIs, treat the new output as a proposed diff rather than overwriting.

## Requirements
- RM-REQ-072, RM-REQ-073

## Acceptance Criteria
- [ ] Diff computation between existing persisted PBI set and newly derived set:
  - Track additions, edge changes, and status-incompatible removals
- [ ] Human acceptance step required before persistence
- [ ] Persisted PBIs are not recomputed-on-read / not ephemeral (cached until re-derivation is accepted)

## Details
This flow ensures that proposed changes to the PBI structure are reviewed and approved before being persisted to the database, maintaining control over the system's state.

## Dependencies
- **Blocked by:** Issue 3 (PBI derivation operation)