### PR TITLE
Issue 84/pbi integration branch (#122)

### DIFF
--- a/src/orchestrator/gateLoop.ts
+++ b/src/orchestrator/gateLoop.ts
@@ -1033,7 +1033,10 @@ export const handleGateLoop = async (
             writeLog(
               `[GateLoop] Task ${activeTaskId} has no existing branch. Creating new branch.`,
             );
-            await getGitSandbox().checkoutTaskBranch(activeTaskId);
+            await getGitSandbox().checkoutTaskBranch(
+              activeTaskId,
+              taskRecord?.pbiId ?? undefined,
+            );
           }
         } catch (err) {
           writeLog(
@@ -1480,7 +1483,10 @@ export const handleGateLoop = async (
               writeLog(
                 `[GateLoop] Task ${activeTaskId} has no existing branch. Creating new branch.`,
               );
-              await getGitSandbox().checkoutTaskBranch(activeTaskId);
+              await getGitSandbox().checkoutTaskBranch(
+                activeTaskId,
+                taskRecord?.pbiId ?? undefined,
+              );
             }
           } catch (err) {
             writeLog(
@@ -2712,6 +2718,54 @@ export const handleGateLoop = async (
               );
             } catch (e: unknown) {
               // suppress git error output
+            }
+
+            // RM-REQ-014/015: fast-forward the completed task branch into
+            // pbi/<pbiId> when this task belongs to a PBI. Trunk is never
+            // touched here (RM-REQ-017) — that happens only via human PR
+            // review once the PBI's compliance audit is clean.
+            if (sessionId && activeSessions.has(sessionId)) {
+              const currentSession = activeSessions.get(sessionId)!;
+              const doneTaskId = currentSession.taskId;
+              const doneTask = doneTaskId ? getTask(doneTaskId) : undefined;
+              if (doneTask && doneTask.pbiId) {
+                try {
+                  await getGitSandbox().mergeTaskIntoPbi(
+                    doneTask.taskId,
+                    doneTask.pbiId,
+                  );
+                  writeLog(
+                    `[GateLoop] Fast-forward merged task/${doneTask.taskId} into pbi/${doneTask.pbiId}.`,
+                  );
+                } catch (mergeErr) {
+                  // RM-REQ-015: no auto three-way merge — fail loudly and
+                  // escalate for human/manual resolution instead.
+                  writeLog(
+                    `[GateLoop] Fast-forward merge of task/${doneTask.taskId} into pbi/${doneTask.pbiId} failed: ${mergeErr}`,
+                    LogLevel.ERROR,
+                  );
+                  try {
+                    appendEscalation({
+                      sessionId,
+                      summary:
+                        `Task ${doneTask.taskId} completed but could not be ` +
+                        `fast-forward merged into pbi/${doneTask.pbiId}. The task ` +
+                        `branch has diverged from the PBI integration branch. ` +
+                        `Manual resolution required: rebase task/${doneTask.taskId} ` +
+                        `onto the current pbi/${doneTask.pbiId} tip, or restart the ` +
+                        `task fresh off the current PBI tip.`,
+                      failedGate: "pbi-ff-merge",
+                      failedGateFeedback: String(mergeErr),
+                      retryHistory: [],
+                    });
+                  } catch (escalateErr) {
+                    writeLog(
+                      `[GateLoop] Failed to record merge-failure escalation: ${escalateErr}`,
+                      LogLevel.ERROR,
+                    );
+                  }
+                }
+              }
             }
 
             if (sessionId && activeSessions.has(sessionId)) {

--- a/src/orchestrator/gateLoop.ts
+++ b/src/orchestrator/gateLoop.ts
@@ -2744,6 +2744,27 @@ export const handleGateLoop = async (
                     `[GateLoop] Fast-forward merge of task/${doneTask.taskId} into pbi/${doneTask.pbiId} failed: ${mergeErr}`,
                     LogLevel.ERROR,
                   );
+                  // Revert the done marking: RM-REQ-014 ties "done" to a
+                  // successfully merged task. Leaving it "done" here would
+                  // let RM-REQ-011 (all-tasks-done → compliance audit) and
+                  // RM-REQ-017 (PR-ready marking) treat the PBI as complete
+                  // when its work never actually landed on pbi/<pbiId>.
+                  try {
+                    const staleTask = getTask(doneTask.taskId);
+                    if (staleTask) {
+                      saveTask({
+                        ...staleTask,
+                        status: "blocked",
+                        blockedReason: `pbi-ff-merge failed: ${String(mergeErr)}`,
+                        updatedAt: Date.now(),
+                      });
+                    }
+                  } catch (revertErr) {
+                    writeLog(
+                      `[GateLoop] Failed to revert task status after merge failure: ${revertErr}`,
+                      LogLevel.ERROR,
+                    );
+                  }
                   try {
                     appendEscalation({
                       sessionId,
@@ -2753,7 +2774,8 @@ export const handleGateLoop = async (
                         `branch has diverged from the PBI integration branch. ` +
                         `Manual resolution required: rebase task/${doneTask.taskId} ` +
                         `onto the current pbi/${doneTask.pbiId} tip, or restart the ` +
-                        `task fresh off the current PBI tip.`,
+                        `task fresh off the current PBI tip. Task status reverted to ` +
+                        `'blocked' pending resolution.`,
                       failedGate: "pbi-ff-merge",
                       failedGateFeedback: String(mergeErr),
                       retryHistory: [],

--- a/src/test/pbi_branch_integration.test.ts
+++ b/src/test/pbi_branch_integration.test.ts
@@ -179,4 +179,36 @@ describe('PBI-level integration branch + fast-forward merge (Issue 84 / RM-REQ-0
     await sandbox.parkTaskBranch(taskId);
     db.prepare('DELETE FROM tasks WHERE taskId = ?').run(taskId);
   });
+
+  it('returns to base branch even when the pbi/<pbiId> checkout itself fails (e.g. pbi branch never created)', async () => {
+    const sandbox = getGitSandbox();
+    const pbiId = 'pbi-never-created-006';
+    const taskId = 'task-no-pbi-branch-006';
+
+    // Register the task with a pbiId, but never call ensurePbiBranch /
+    // checkoutTaskBranch(taskId, pbiId) for it — simulates the case where
+    // pbi branch creation was silently swallowed upstream (checkoutTaskBranch
+    // catches ensurePbiBranchImpl failures), so pbi/<pbiId> never exists.
+    registerPbi(pbiId);
+    registerTask(taskId, pbiId);
+
+    // Task still needs *a* branch to attempt a merge from, so it's fine for
+    // this to be a plain trunk-based branch — the point under test is the
+    // checkout of the (nonexistent) pbi branch failing, not the merge itself.
+    await sandbox.checkoutTaskBranch(taskId);
+
+    await expect(sandbox.mergeTaskIntoPbi(taskId, pbiId)).rejects.toThrow();
+
+    // Regression check: previously the checkout of pbi/<pbiId> sat outside
+    // the try/finally, so a failure here left the sandbox on whatever branch
+    // it was on rather than returning to base. Verify recovery is clean by
+    // confirming a fresh checkoutTaskBranch call succeeds immediately after.
+    const otherTaskId = 'task-followup-006';
+    registerTask(otherTaskId, pbiId);
+    await expect(sandbox.checkoutTaskBranch(otherTaskId)).resolves.toBeDefined();
+
+    await sandbox.parkTaskBranch(otherTaskId);
+    db.prepare('DELETE FROM tasks WHERE taskId IN (?, ?)').run(taskId, otherTaskId);
+    db.prepare('DELETE FROM pbis WHERE pbiId = ?').run(pbiId);
+  });
 });

--- a/src/test/pbi_branch_integration.test.ts
+++ b/src/test/pbi_branch_integration.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, beforeAll, expect } from 'vitest';
+import * as path from 'path';
+import * as fs from 'fs';
+import { initializeWorkspace, getGitSandbox, getWorkspaceRoot } from '../workspace';
+import { db } from '../db/index';
+import { saveTask, getTask, saveSpec } from '../db/taskStore';
+import { savePbi } from '../db/pbiStore';
+
+describe('PBI-level integration branch + fast-forward merge (Issue 84 / RM-REQ-014/015/016)', () => {
+  beforeAll(async () => {
+    await initializeWorkspace();
+
+    saveSpec({
+      specId: 'spec-pbi-test',
+      filePath: 'architecture-spec.md',
+      version: 'v1',
+      createdAt: Date.now(),
+    });
+  });
+
+  function registerPbi(pbiId: string) {
+    savePbi({
+      pbiId,
+      specId: 'spec-pbi-test',
+      title: `Test PBI ${pbiId}`,
+      description: 'A test PBI for integration-branch tests',
+      status: 'in_progress',
+      dependsOn: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  }
+
+  function registerTask(taskId: string, pbiId: string) {
+    saveTask({
+      taskId,
+      specId: 'spec-pbi-test',
+      specVersion: 'v1',
+      title: `Test Task ${taskId}`,
+      description: 'A test task for PBI branch isolation',
+      status: 'pending',
+      touches: null,
+      dependsOn: null,
+      branchName: null,
+      blockedReason: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      pbiId,
+    });
+  }
+
+  it('creates pbi/<pbiId> off trunk on first use, and is idempotent on repeat calls', async () => {
+    const sandbox = getGitSandbox();
+    const pbiId = 'pbi-ensure-001';
+    registerPbi(pbiId);
+
+    await sandbox.ensurePbiBranch(pbiId);
+    const shaAfterFirst = await sandbox.getHeadShaAsync();
+
+    // Calling again should not fail, and should not create a duplicate or
+    // move the branch — it just checks the existing branch back out.
+    await sandbox.ensurePbiBranch(pbiId);
+    const shaAfterSecond = await sandbox.getHeadShaAsync();
+
+    expect(shaAfterSecond).toBe(shaAfterFirst);
+
+    db.prepare('DELETE FROM pbis WHERE pbiId = ?').run(pbiId);
+  });
+
+  it('branches a task off pbi/<pbiId> (not trunk) when a PBI context exists', async () => {
+    const sandbox = getGitSandbox();
+    const pbiId = 'pbi-branch-002';
+    const taskId = 'task-branch-002';
+    registerPbi(pbiId);
+    registerTask(taskId, pbiId);
+
+    // Put a marker file on the PBI branch before any task branches off it.
+    await sandbox.ensurePbiBranch(pbiId);
+    const marker = path.join(getWorkspaceRoot(), 'pbi-002-marker.txt');
+    fs.writeFileSync(marker, 'exists only on pbi/pbi-branch-002', 'utf8');
+    await sandbox.commitAllChangesAsync('Add PBI marker file');
+
+    // Checking out the task branch with a pbiId should branch off the PBI
+    // branch, so the marker file must be present.
+    await sandbox.checkoutTaskBranch(taskId, pbiId);
+    expect(fs.existsSync(marker)).toBe(true);
+
+    const task = getTask(taskId);
+    expect(task?.branchName).toBe(`task/${taskId}`);
+
+    await sandbox.parkTaskBranch(taskId);
+    db.prepare('DELETE FROM tasks WHERE taskId = ?').run(taskId);
+    db.prepare('DELETE FROM pbis WHERE pbiId = ?').run(pbiId);
+  });
+
+  it('fast-forward merges a completed task branch into pbi/<pbiId>', async () => {
+    const sandbox = getGitSandbox();
+    const pbiId = 'pbi-merge-003';
+    const taskId = 'task-merge-003';
+    registerPbi(pbiId);
+    registerTask(taskId, pbiId);
+
+    await sandbox.checkoutTaskBranch(taskId, pbiId);
+    const taskFile = path.join(getWorkspaceRoot(), 'task-003-output.txt');
+    fs.writeFileSync(taskFile, 'work completed by task-merge-003', 'utf8');
+    await sandbox.commitAllChangesAsync('Complete task-merge-003');
+
+    await sandbox.mergeTaskIntoPbi(taskId, pbiId);
+
+    // Verify the file landed on pbi/<pbiId> by checking it out directly.
+    await sandbox.checkoutAsync(`pbi/${pbiId}`);
+    expect(fs.existsSync(taskFile)).toBe(true);
+
+    // mergeTaskIntoPbi should leave the sandbox back on the base branch.
+    await sandbox.checkoutAsync('main').catch(() => sandbox.checkoutAsync('master'));
+
+    db.prepare('DELETE FROM tasks WHERE taskId = ?').run(taskId);
+    db.prepare('DELETE FROM pbis WHERE pbiId = ?').run(pbiId);
+  });
+
+  it('throws (no auto three-way merge) when the task branch has diverged from pbi/<pbiId>, and returns to base', async () => {
+    const sandbox = getGitSandbox();
+    const pbiId = 'pbi-diverge-004';
+    const taskId = 'task-diverge-004';
+    registerPbi(pbiId);
+    registerTask(taskId, pbiId);
+
+    // Task branches off pbi/<pbiId> and does its own work.
+    await sandbox.checkoutTaskBranch(taskId, pbiId);
+    const taskFile = path.join(getWorkspaceRoot(), 'task-004-output.txt');
+    fs.writeFileSync(taskFile, 'work by task-diverge-004', 'utf8');
+    await sandbox.commitAllChangesAsync('Complete task-diverge-004');
+
+    // Meanwhile pbi/<pbiId> itself moves forward independently (e.g. another
+    // task already merged into it), so a fast-forward is no longer possible.
+    await sandbox.checkoutAsync(`pbi/${pbiId}`);
+    const pbiFile = path.join(getWorkspaceRoot(), 'pbi-004-independent.txt');
+    fs.writeFileSync(pbiFile, 'independent pbi-level commit', 'utf8');
+    await sandbox.commitAllChangesAsync('Independent PBI-level commit');
+
+    await expect(sandbox.mergeTaskIntoPbi(taskId, pbiId)).rejects.toThrow();
+
+    // Even on failure, the sandbox must be left back on the base branch
+    // (never mid-merge or stuck on the PBI branch) so the next task can run.
+    const currentBranch = await sandbox.checkoutAsync('main').then(
+      () => 'main',
+      () => 'master'
+    );
+    expect(['main', 'master']).toContain(currentBranch);
+
+    db.prepare('DELETE FROM tasks WHERE taskId = ?').run(taskId);
+    db.prepare('DELETE FROM pbis WHERE pbiId = ?').run(pbiId);
+  });
+
+  it('non-PBI tasks (no pbiId) still branch directly off trunk, unaffected by this change', async () => {
+    const sandbox = getGitSandbox();
+    const taskId = 'task-no-pbi-005';
+
+    saveTask({
+      taskId,
+      specId: 'spec-pbi-test',
+      specVersion: 'v1',
+      title: 'Non-PBI task',
+      description: 'A task with no PBI context',
+      status: 'pending',
+      touches: null,
+      dependsOn: null,
+      branchName: null,
+      blockedReason: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      pbiId: null,
+    });
+
+    await sandbox.checkoutTaskBranch(taskId);
+    const task = getTask(taskId);
+    expect(task?.branchName).toBe(`task/${taskId}`);
+
+    await sandbox.parkTaskBranch(taskId);
+    db.prepare('DELETE FROM tasks WHERE taskId = ?').run(taskId);
+  });
+});

--- a/src/workspace/git.ts
+++ b/src/workspace/git.ts
@@ -146,13 +146,46 @@ export class GitSandbox {
         return this.withLock(() => this.git(["checkout", branchName]));
     }
 
-    public async checkoutTaskBranch(taskId: string): Promise<string> {
+    /**
+     * Ensures `pbi/<pbiId>` exists, branched off trunk if it doesn't already.
+     * Leaves the sandbox checked out on `pbi/<pbiId>`. Idempotent — safe to
+     * call on every task within a PBI, not just the first.
+     * (RM-REQ-014: PBI-level integration branch, created off trunk when a
+     * PBI's first task begins.)
+     */
+    private async ensurePbiBranchImpl(pbiId: string): Promise<void> {
+        const pbiBranch = `pbi/${pbiId}`;
+        const exists = await this.git(["branch", "--list", pbiBranch]).then(
+            (out) => out.trim().length > 0
+        );
+        if (exists) {
+            await this.git(["checkout", pbiBranch]);
+            return;
+        }
+        await this.checkoutBaseBranch();
+        await this.git(["checkout", "-b", pbiBranch]);
+    }
+
+    public async ensurePbiBranch(pbiId: string): Promise<void> {
+        return this.withLock(() => this.ensurePbiBranchImpl(pbiId));
+    }
+
+    /**
+     * Branches a task off `pbi/<pbiId>` when a PBI context exists, or off
+     * trunk directly when it doesn't (non-PBI tasks keep the original
+     * behavior). (RM-REQ-014.)
+     */
+    public async checkoutTaskBranch(taskId: string, pbiId?: string): Promise<string> {
         return this.withLock(async () => {
-            // Return to base branch first so we don't try to delete the active branch
+            // Return to the correct base first so we don't try to delete the active branch.
             try {
-                await this.checkoutBaseBranch();
+                if (pbiId) {
+                    await this.ensurePbiBranchImpl(pbiId);
+                } else {
+                    await this.checkoutBaseBranch();
+                }
             } catch (e) {
-                console.warn(`[GitSandbox] Failed to checkout base branch:`, e);
+                console.warn(`[GitSandbox] Failed to checkout base for task branch:`, e);
                 // Ignore failure if we can't switch, but try to proceed
             }
 
@@ -179,6 +212,32 @@ export class GitSandbox {
                 // Ignore or log error
             }
             return out;
+        });
+    }
+
+    /**
+     * Fast-forward-merges `task/<taskId>` into `pbi/<pbiId>` on task completion.
+     * Throws (no auto three-way merge) if a fast-forward is not possible —
+     * callers are expected to catch this and raise an escalation.
+     * Leaves the sandbox back on the base trunk branch afterward, win or lose,
+     * consistent with `parkTaskBranch`. Trunk itself is never touched here
+     * (RM-REQ-014/RM-REQ-017 — trunk stays untouched until human PR review).
+     */
+    public async mergeTaskIntoPbi(taskId: string, pbiId: string): Promise<void> {
+        return this.withLock(async () => {
+            const pbiBranch = `pbi/${pbiId}`;
+            await this.git(["checkout", pbiBranch]);
+            try {
+                await this.git(["merge", "--ff-only", `task/${taskId}`]);
+            } finally {
+                // Always return to base branch afterward, success or failure,
+                // so the sandbox is left in a known state for the next task.
+                try {
+                    await this.checkoutBaseBranch();
+                } catch (e) {
+                    console.warn(`[GitSandbox] Failed to checkout base branch after merge:`, e);
+                }
+            }
         });
     }
 

--- a/src/workspace/git.ts
+++ b/src/workspace/git.ts
@@ -226,12 +226,14 @@ export class GitSandbox {
     public async mergeTaskIntoPbi(taskId: string, pbiId: string): Promise<void> {
         return this.withLock(async () => {
             const pbiBranch = `pbi/${pbiId}`;
-            await this.git(["checkout", pbiBranch]);
             try {
+                await this.git(["checkout", pbiBranch]);
                 await this.git(["merge", "--ff-only", `task/${taskId}`]);
             } finally {
-                // Always return to base branch afterward, success or failure,
-                // so the sandbox is left in a known state for the next task.
+                // Always return to base branch afterward, success or failure —
+                // including if the checkout of pbiBranch itself failed (e.g.
+                // pbi/<pbiId> doesn't exist) — so the sandbox is never left
+                // stuck mid-operation for the next task.
                 try {
                     await this.checkoutBaseBranch();
                 } catch (e) {


### PR DESCRIPTION
## Overview
Introduce PBI-level integration branches (`pbi/<pbiId>`) with a strict fast-forward merge policy. Each task within a PBI branches from the PBI's integration branch and fast-forward-merges back on completion.

## Requirements
- RM-REQ-014, RM-REQ-015, RM-REQ-016

## Acceptance Criteria
- [ ] `checkoutTaskBranch` (or new function) in `src/workspace/git.ts` branches off `pbi/<pbiId>` when a PBI context exists
- [ ] Fast-forward merge implemented on task `done` status
- [ ] Non-fast-forward case raises an escalation, no auto three-way merge
- [ ] Checkpoint restore behavior updated per RM-REQ-016 (commits onto task's active branch, not directly onto `pbi/<pbiId>`)

## Details
Currently `checkoutTaskBranch` always branches fresh off trunk with no merge/fast-forward step. This change:
- Creates `pbi/<pbiId>` branch off trunk when a PBI's first task begins
- Each task branches off `pbi/<pbiId>` instead of trunk
- Tasks fast-forward-merge into `pbi/<pbiId>` on `done`
- Trunk stays untouched (consistent with SYS-REQ-021)
- If fast-forward is not possible, fail loudly and raise escalation

## Dependencies
- **Blocked by:** Issue 1 (Introduce PBI tier), Issue 7 (branch-strategy decision)