### PR TITLE
Issue 81: tiered escalation for compliance-audit remediation (#129)

### DIFF
--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -24,6 +24,7 @@ export interface SystemRolesConfig {
   readonly planner: ModelProviderConfig;
   readonly executorTiers: readonly ModelProviderConfig[]; // Tiered ladder for execution
   readonly auditor: ModelProviderConfig;
+  readonly auditorTiers: readonly ModelProviderConfig[]; // Tiered escalation ladder for the compliance-audit operation (Issue 81)
   readonly reviewer: ModelProviderConfig;
 }
 
@@ -129,6 +130,39 @@ export const DEFAULT_ROLES_CONFIG: SystemRolesConfig = {
       tokenRatio: 3.5,
     };
   },
+  /**
+   * Tiered escalation ladder for auditor roles (Issue 81 / RM-REQ-021):
+   * mirrors executorTiers' shape so compliance-audit re-runs can escalate to
+   * a stronger model when repeated audits keep finding issues after a full
+   * remediation cycle. Tier 0 intentionally matches the `auditor` getter
+   * above (including its AUDITOR_PROVIDER/AUDITOR_MODEL env override) so
+   * existing single-tier auditor configuration keeps working unchanged.
+   */
+  get auditorTiers(): readonly ModelProviderConfig[] {
+    return [
+      this.auditor,
+      {
+        provider:
+          (typeof process !== "undefined" &&
+            (isProviderType(process.env?.AUDITOR_TIER_1_PROVIDER) ? process.env?.AUDITOR_TIER_1_PROVIDER : undefined)) ||
+          "gemini",
+        model:
+          (typeof process !== "undefined" && process.env?.AUDITOR_TIER_1_MODEL) ||
+          "gemini-3.5-flash",
+        tokenRatio: 3.5,
+      },
+      {
+        provider:
+          (typeof process !== "undefined" &&
+            (isProviderType(process.env?.AUDITOR_TIER_2_PROVIDER) ? process.env?.AUDITOR_TIER_2_PROVIDER : undefined)) ||
+          "gemini",
+        model:
+          (typeof process !== "undefined" && process.env?.AUDITOR_TIER_2_MODEL) ||
+          "gemini-3.1-pro-preview",
+        tokenRatio: 3.0,
+      },
+    ];
+  },
   get reviewer() {
     return {
       provider:
@@ -164,4 +198,29 @@ export function getNextTier(model: string): string | null {
     return null;
   }
   return MODEL_TIERS[index + 1] || null;
+}
+
+/**
+ * Index-based accessor for the auditor tier ladder (Issue 81 / RM-REQ-021).
+ * Clamps to the highest configured tier rather than throwing, mirroring
+ * getExecutorTier's clamping behavior -- callers track tier progress by
+ * index (persisted on the PBI record), not by model name.
+ */
+export function getAuditorTierConfig(tierIndex: number): ModelProviderConfig {
+  const tiers = DEFAULT_ROLES_CONFIG.auditorTiers;
+  if (tiers.length === 0) {
+    throw new Error("No auditor tiers defined");
+  }
+  if (tierIndex < 0) {
+    return tiers[0]!;
+  }
+  if (tierIndex >= tiers.length) {
+    return tiers[tiers.length - 1]!;
+  }
+  return tiers[tierIndex]!;
+}
+
+/** Highest valid auditor tier index -- reaching this and still failing is a terminal escalation (RM-REQ-022). */
+export function getAuditorMaxTierIndex(): number {
+  return DEFAULT_ROLES_CONFIG.auditorTiers.length - 1;
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -30,7 +30,9 @@ db.exec(`
     status TEXT CHECK(status IN ('pending','in_progress','blocked','done')) DEFAULT 'pending',
     dependsOn TEXT,              -- JSON array of pbiIds
     createdAt INTEGER,
-    updatedAt INTEGER
+    updatedAt INTEGER,
+    auditTierIndex INTEGER DEFAULT 0,      -- Issue 81/RM-REQ-021: compliance-audit's own escalation tier
+    lastAuditHadFindings INTEGER DEFAULT 0 -- Issue 81: 0/1 -- was the most recent audit's result a finding (mid remediation cycle)?
   );
 
   CREATE TABLE IF NOT EXISTS tasks (
@@ -91,4 +93,12 @@ if (!sessionsColumns.some(col => col.name === 'taskId')) {
 const tasksColumns = db.pragma('table_info(tasks)') as { name: string }[];
 if (!tasksColumns.some(col => col.name === 'pbiId')) {
   db.prepare('ALTER TABLE tasks ADD COLUMN pbiId TEXT REFERENCES pbis(pbiId)').run();
+}
+
+const pbisColumns = db.pragma('table_info(pbis)') as { name: string }[];
+if (!pbisColumns.some(col => col.name === 'auditTierIndex')) {
+  db.prepare('ALTER TABLE pbis ADD COLUMN auditTierIndex INTEGER DEFAULT 0').run();
+}
+if (!pbisColumns.some(col => col.name === 'lastAuditHadFindings')) {
+  db.prepare('ALTER TABLE pbis ADD COLUMN lastAuditHadFindings INTEGER DEFAULT 0').run();
 }

--- a/src/db/pbiStore.ts
+++ b/src/db/pbiStore.ts
@@ -9,14 +9,45 @@ export interface PbiRecord {
   readonly dependsOn: string | null; // JSON string of pbiIds
   readonly createdAt: number;
   readonly updatedAt: number;
+  /** Issue 81/RM-REQ-021: compliance-audit's own escalation tier for this PBI. Defaults to 0. */
+  readonly auditTierIndex?: number;
+  /**
+   * Issue 81: whether the most recently *run* compliance audit for this PBI
+   * reported findings. Used to distinguish a first-time finding (creates
+   * remediation tasks, tier unchanged) from a repeat finding after a
+   * completed remediation cycle (escalates the audit's own tier per
+   * RM-REQ-021). Reset to false on a clean pass.
+   */
+  readonly lastAuditHadFindings?: boolean;
+}
+
+interface PbiRow {
+  readonly pbiId: string;
+  readonly specId: string;
+  readonly title: string;
+  readonly description: string | null;
+  readonly status: 'pending' | 'in_progress' | 'blocked' | 'done';
+  readonly dependsOn: string | null;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly auditTierIndex: number | null;
+  readonly lastAuditHadFindings: number | null;
+}
+
+function rowToPbi(row: PbiRow): PbiRecord {
+  return {
+    ...row,
+    auditTierIndex: row.auditTierIndex ?? 0,
+    lastAuditHadFindings: !!row.lastAuditHadFindings,
+  };
 }
 
 export function savePbi(pbi: PbiRecord): void {
   const stmt = db.prepare(`
     INSERT INTO pbis (
-      pbiId, specId, title, description, status, dependsOn, createdAt, updatedAt
+      pbiId, specId, title, description, status, dependsOn, createdAt, updatedAt, auditTierIndex, lastAuditHadFindings
     ) VALUES (
-      @pbiId, @specId, @title, @description, @status, @dependsOn, @createdAt, @updatedAt
+      @pbiId, @specId, @title, @description, @status, @dependsOn, @createdAt, @updatedAt, @auditTierIndex, @lastAuditHadFindings
     )
     ON CONFLICT(pbiId) DO UPDATE SET
       specId = excluded.specId,
@@ -24,7 +55,9 @@ export function savePbi(pbi: PbiRecord): void {
       description = excluded.description,
       status = excluded.status,
       dependsOn = excluded.dependsOn,
-      updatedAt = excluded.updatedAt
+      updatedAt = excluded.updatedAt,
+      auditTierIndex = excluded.auditTierIndex,
+      lastAuditHadFindings = excluded.lastAuditHadFindings
   `);
   stmt.run({
     pbiId: pbi.pbiId,
@@ -35,15 +68,19 @@ export function savePbi(pbi: PbiRecord): void {
     dependsOn: pbi.dependsOn,
     createdAt: pbi.createdAt,
     updatedAt: pbi.updatedAt,
+    auditTierIndex: pbi.auditTierIndex ?? 0,
+    lastAuditHadFindings: pbi.lastAuditHadFindings ? 1 : 0,
   });
 }
 
 export function getPbi(pbiId: string): PbiRecord | undefined {
-  return db.prepare('SELECT * FROM pbis WHERE pbiId = ?').get(pbiId) as PbiRecord | undefined;
+  const row = db.prepare('SELECT * FROM pbis WHERE pbiId = ?').get(pbiId) as PbiRow | undefined;
+  return row ? rowToPbi(row) : undefined;
 }
 
 export function getPbisForSpec(specId: string): PbiRecord[] {
-  return db.prepare('SELECT * FROM pbis WHERE specId = ? ORDER BY createdAt ASC').all(specId) as PbiRecord[];
+  const rows = db.prepare('SELECT * FROM pbis WHERE specId = ? ORDER BY createdAt ASC').all(specId) as PbiRow[];
+  return rows.map(rowToPbi);
 }
 
 export function deletePbisForSpec(specId: string): void {

--- a/src/gates/complianceAudit.ts
+++ b/src/gates/complianceAudit.ts
@@ -194,12 +194,23 @@ export async function runComplianceAudit(
   }
 
   // RM-REQ-021: distinguish a first-time finding (mid-cycle, tier
-  // unchanged) from a *repeat* finding -- this audit is only reached again
-  // for the same PBI once the prior cycle's remediation tasks have all
-  // completed (shouldTriggerComplianceAudit's end-of-pbi trigger), so
-  // `lastAuditHadFindings` being true here means a full remediation cycle
-  // ran and the problem persists.
-  const isRepeatFailure = pbi.lastAuditHadFindings === true;
+  // unchanged) from a *repeat* finding after a full remediation cycle.
+  // `lastAuditHadFindings` alone is not sufficient: shouldTriggerComplianceAudit's
+  // periodic trigger (RM-REQ-012) can fire this audit again while some of the
+  // prior cycle's remediation tasks (which carry this same pbiId) are still
+  // pending -- e.g. one remediation task done, others not, but doneCount hits
+  // another periodic multiple. Escalating the audit tier or parking the PBI
+  // in that situation would be premature: the remediation cycle hasn't
+  // actually finished yet, so this audit run doesn't tell us anything about
+  // whether the remediation worked. Only treat this as a genuine repeat
+  // failure once every task on the PBI (including all remediation tasks) is
+  // done -- i.e. this audit was reached via the end-of-pbi trigger, or a
+  // periodic trigger that happens to coincide with full completion.
+  const allTasksForPbiDone = (() => {
+    const tasks = getTasksForPbi(pbiId);
+    return tasks.length > 0 && tasks.every((t) => t.status === 'done');
+  })();
+  const isRepeatFailure = pbi.lastAuditHadFindings === true && allTasksForPbiDone;
   const now = Date.now();
 
   if (isRepeatFailure) {

--- a/src/gates/complianceAudit.ts
+++ b/src/gates/complianceAudit.ts
@@ -3,6 +3,7 @@ import { submitComplianceAuditTool } from '../config/tools';
 import { getGitSandbox, getExecCommand, getWorkspaceRoot } from '../workspace';
 import { getPbi, savePbi } from '../db/pbiStore';
 import { getTasksForPbi, saveTask, getSpec, TaskRecord } from '../db/taskStore';
+import { getAuditorMaxTierIndex } from '../config/models';
 import crypto from 'crypto';
 
 export interface ComplianceFinding {
@@ -10,12 +11,40 @@ export interface ComplianceFinding {
   readonly description: string;
 }
 
+/**
+ * Distinguishes the remediation scenario an audit result falls into
+ * (Issue 81 acceptance criteria: "Escalation entries distinguish between
+ * different remediation scenarios"):
+ * - 'clean': no findings; PBI marked done.
+ * - 'findings-first-pass': findings on the first audit of this cycle;
+ *   remediation tasks created via the normal task escalation ladder,
+ *   audit's own tier unchanged.
+ * - 'findings-audit-escalated': the *next* audit after a remediation cycle
+ *   completed still found issues -- the audit's own model tier is escalated
+ *   (RM-REQ-021) and further remediation tasks are created at the new tier.
+ * - 'findings-pbi-parked': the audit was already on its highest tier and
+ *   still found issues after a full remediation cycle -- the entire PBI is
+ *   parked and a human escalation is raised (RM-REQ-022), no further
+ *   remediation tasks are created.
+ */
+export type ComplianceAuditScenario =
+  | 'clean'
+  | 'findings-first-pass'
+  | 'findings-audit-escalated'
+  | 'findings-pbi-parked';
+
 export interface ComplianceAuditResult {
   readonly pbiId: string;
   readonly pass: boolean;
   readonly findings: readonly ComplianceFinding[];
   /** taskIds of the remediation tasks created for this audit's findings, if any. */
   readonly remediationTaskIds: readonly string[];
+  /** Which remediation scenario this result represents (Issue 81). */
+  readonly scenario: ComplianceAuditScenario;
+  /** The auditor tier index this audit ran at. */
+  readonly auditTierIndex: number;
+  /** True if this audit result parked the entire PBI (RM-REQ-022). */
+  readonly pbiParked: boolean;
 }
 
 interface ComplianceAuditToolResult {
@@ -88,7 +117,15 @@ export async function runComplianceAudit(
     // Nothing accumulated on the PBI branch yet -- nothing to audit.
     // Deliberately does not mark the PBI done: an empty diff is not the
     // same claim as "the diff satisfies the spec".
-    return { pbiId, pass: true, findings: [], remediationTaskIds: [] };
+    return {
+      pbiId,
+      pass: true,
+      findings: [],
+      remediationTaskIds: [],
+      scenario: 'clean',
+      auditTierIndex: pbi.auditTierIndex ?? 0,
+      pbiParked: false,
+    };
   }
 
   // Spec scoping: the roadmap calls for auditing against "the subset of the
@@ -113,7 +150,8 @@ export async function runComplianceAudit(
     }
   }
 
-  const executionConfig = getAuditorExecutionConfig();
+  const auditTierIndex = pbi.auditTierIndex ?? 0;
+  const executionConfig = getAuditorExecutionConfig(undefined, auditTierIndex);
   const userPrompt = buildUserPrompt(pbi.title, pbi.description ?? '', specContent, diff);
 
   const result = await executeAuditSession<ComplianceAuditToolResult>(
@@ -133,16 +171,71 @@ export async function runComplianceAudit(
   }
 
   if (result.pass && result.findings.length === 0) {
-    savePbi({ ...pbi, status: 'done', updatedAt: Date.now() });
-    return { pbiId, pass: true, findings: [], remediationTaskIds: [] };
+    // A clean pass resets the audit escalation ladder (RM-REQ-021 only
+    // applies to *repeated* failures) -- a subsequent finding on some later
+    // remediation cycle should start back at tier 0, not inherit an
+    // escalated tier from an unrelated earlier cycle.
+    savePbi({
+      ...pbi,
+      status: 'done',
+      auditTierIndex: 0,
+      lastAuditHadFindings: false,
+      updatedAt: Date.now(),
+    });
+    return {
+      pbiId,
+      pass: true,
+      findings: [],
+      remediationTaskIds: [],
+      scenario: 'clean',
+      auditTierIndex: 0,
+      pbiParked: false,
+    };
   }
 
-  // RM-REQ-013: findings create new tasks via this structured tool-call
-  // result directly, not by writing prose for the regex-based decomposer.
-  const existingTasks = getTasksForPbi(pbiId);
+  // RM-REQ-021: distinguish a first-time finding (mid-cycle, tier
+  // unchanged) from a *repeat* finding -- this audit is only reached again
+  // for the same PBI once the prior cycle's remediation tasks have all
+  // completed (shouldTriggerComplianceAudit's end-of-pbi trigger), so
+  // `lastAuditHadFindings` being true here means a full remediation cycle
+  // ran and the problem persists.
+  const isRepeatFailure = pbi.lastAuditHadFindings === true;
+  const now = Date.now();
+
+  if (isRepeatFailure) {
+    const maxTierIndex = getAuditorMaxTierIndex();
+    if (auditTierIndex >= maxTierIndex) {
+      // RM-REQ-022: highest-tier persistent failure after a full
+      // remediation cycle -- park the entire PBI (not just individual
+      // tasks) rather than spinning up yet more remediation tasks, and
+      // signal the caller to raise an async human escalation.
+      savePbi({
+        ...pbi,
+        status: 'blocked',
+        auditTierIndex,
+        lastAuditHadFindings: true,
+        updatedAt: now,
+      });
+      return {
+        pbiId,
+        pass: false,
+        findings: result.findings,
+        remediationTaskIds: [],
+        scenario: 'findings-pbi-parked',
+        auditTierIndex,
+        pbiParked: true,
+      };
+    }
+  }
+
+  // RM-REQ-013/RM-REQ-020: findings create new remediation tasks via this
+  // structured tool-call result directly, not by writing prose for the
+  // regex-based decomposer. These tasks then go through the *same* tiered
+  // task-escalation ladder (retry same model -> escalate model tier -> park)
+  // that gateLoop.ts already applies to every ordinary task -- no separate
+  // remediation-specific ladder is needed for the tasks themselves.
   const specVersion = specRecord?.version ?? 'unknown';
   const remediationTaskIds: string[] = [];
-  const now = Date.now();
 
   for (const finding of result.findings) {
     const taskId = `${pbiId}-remediation-${crypto.randomBytes(4).toString('hex')}`;
@@ -165,14 +258,28 @@ export async function runComplianceAudit(
     remediationTaskIds.push(taskId);
   }
 
-  // RM-REQ-013: mark the PBI's completion state as not-yet-satisfied.
-  savePbi({ ...pbi, status: 'in_progress', updatedAt: now });
+  const nextAuditTierIndex = isRepeatFailure ? auditTierIndex + 1 : auditTierIndex;
+
+  // RM-REQ-013: mark the PBI's completion state as not-yet-satisfied, and
+  // (RM-REQ-021) escalate the audit's own tier if this was a repeat failure,
+  // recording that a finding is now pending so the *next* audit for this PBI
+  // is correctly recognized as a potential repeat.
+  savePbi({
+    ...pbi,
+    status: 'in_progress',
+    auditTierIndex: nextAuditTierIndex,
+    lastAuditHadFindings: true,
+    updatedAt: now,
+  });
 
   return {
     pbiId,
     pass: false,
     findings: result.findings,
     remediationTaskIds,
+    scenario: isRepeatFailure ? 'findings-audit-escalated' : 'findings-first-pass',
+    auditTierIndex: nextAuditTierIndex,
+    pbiParked: false,
   };
 }
 

--- a/src/orchestrator/gateLoop.ts
+++ b/src/orchestrator/gateLoop.ts
@@ -2759,8 +2759,50 @@ export const handleGateLoop = async (
                       } else {
                         writeLog(
                           `[GateLoop] Compliance audit for pbi/${doneTask.pbiId} reported ${auditResult.findings.length} finding(s); ` +
-                          `created remediation tasks: ${auditResult.remediationTaskIds.join(', ')}.`,
+                          `scenario: ${auditResult.scenario}; ` +
+                          `created remediation tasks: ${auditResult.remediationTaskIds.join(', ') || '(none)'}.`,
                         );
+
+                        // Issue 81 / RM-REQ-021/022: the audit's own tier
+                        // escalating, or the PBI getting parked, are distinct
+                        // from an ordinary first-pass finding (which already
+                        // has a natural trail via the created remediation
+                        // tasks) -- raise a dedicated escalation entry so
+                        // these scenarios are distinguishable in the UI.
+                        if (
+                          sessionId &&
+                          (auditResult.scenario === "findings-audit-escalated" ||
+                            auditResult.scenario === "findings-pbi-parked")
+                        ) {
+                          try {
+                            const summary =
+                              auditResult.scenario === "findings-pbi-parked"
+                                ? `Compliance audit for pbi/${doneTask.pbiId} still found ${auditResult.findings.length} issue(s) ` +
+                                  `after a full remediation cycle at the highest auditor tier (tier ${auditResult.auditTierIndex}). ` +
+                                  `The entire PBI has been parked (status: blocked) rather than creating further remediation tasks. ` +
+                                  `Manual review required.`
+                                : `Compliance audit for pbi/${doneTask.pbiId} still found ${auditResult.findings.length} issue(s) ` +
+                                  `after a full remediation cycle. Escalated the compliance auditor to tier ${auditResult.auditTierIndex} ` +
+                                  `and created new remediation tasks: ${auditResult.remediationTaskIds.join(', ')}.`;
+                            appendEscalation({
+                              sessionId,
+                              summary,
+                              failedGate:
+                                auditResult.scenario === "findings-pbi-parked"
+                                  ? "compliance-audit-pbi-parked"
+                                  : "compliance-audit-tier-escalated",
+                              failedGateFeedback: auditResult.findings
+                                .map((f) => `${f.title}: ${f.description}`)
+                                .join("\n"),
+                              retryHistory: [],
+                            });
+                          } catch (escalateErr) {
+                            writeLog(
+                              `[GateLoop] Failed to record compliance-audit escalation entry: ${escalateErr}`,
+                              LogLevel.ERROR,
+                            );
+                          }
+                        }
                       }
                     }
                   } catch (auditErr) {

--- a/src/test/compliance_audit.test.ts
+++ b/src/test/compliance_audit.test.ts
@@ -239,12 +239,20 @@ describe('Compliance-audit operation (Issue 82 / RM-REQ-010/011/012/013)', () =>
       });
       const first = await runComplianceAudit(getWorkspaceRoot(), pbiId);
       expect(first.scenario).toBe('findings-first-pass');
+      expect(first.remediationTaskIds).toHaveLength(1);
 
-      // Simulate the remediation cycle completing and drifting further.
+      // Simulate the remediation cycle actually completing: the remediation
+      // task's work lands on pbi/<pbiId> AND the task itself is marked done
+      // (both are required for allTasksForPbiDone -- merely merging more
+      // commits onto the branch without completing the task is exactly the
+      // premature-escalation bug this guards against).
+      const remediationTaskId = first.remediationTaskIds[0]!;
       fs.writeFileSync(path.join(getWorkspaceRoot(), 'remediation-output.txt'), 'still incomplete', 'utf8');
-      await getGitSandbox().checkoutTaskBranch('remediation-cycle-branch', pbiId);
+      await getGitSandbox().checkoutTaskBranch(remediationTaskId, pbiId);
       await getGitSandbox().commitAllChangesAsync('Remediation attempt');
-      await getGitSandbox().mergeTaskIntoPbi('remediation-cycle-branch', pbiId);
+      await getGitSandbox().mergeTaskIntoPbi(remediationTaskId, pbiId);
+      const remediationTask = getTasksForPbi(pbiId).find((t) => t.taskId === remediationTaskId)!;
+      saveTask({ ...remediationTask, status: 'done', updatedAt: Date.now() });
 
       // Second (repeat) audit: still finds an issue -- must escalate tier.
       mockedExecuteAuditSession.mockResolvedValue({
@@ -272,10 +280,13 @@ describe('Compliance-audit operation (Issue 82 / RM-REQ-010/011/012/013)', () =>
 
       // A third audit run (after the tier-1 remediation cycle completes)
       // must actually use the escalated tier.
+      const secondRemediationTaskId = second.remediationTaskIds[0]!;
       fs.writeFileSync(path.join(getWorkspaceRoot(), 'remediation-2-output.txt'), 'yet another attempt', 'utf8');
-      await getGitSandbox().checkoutTaskBranch('remediation-cycle-branch-2', pbiId);
+      await getGitSandbox().checkoutTaskBranch(secondRemediationTaskId, pbiId);
       await getGitSandbox().commitAllChangesAsync('Second remediation attempt');
-      await getGitSandbox().mergeTaskIntoPbi('remediation-cycle-branch-2', pbiId);
+      await getGitSandbox().mergeTaskIntoPbi(secondRemediationTaskId, pbiId);
+      const secondRemediationTask = getTasksForPbi(pbiId).find((t) => t.taskId === secondRemediationTaskId)!;
+      saveTask({ ...secondRemediationTask, status: 'done', updatedAt: Date.now() });
 
       mockedExecuteAuditSession.mockResolvedValue({ pass: true, findings: [] });
       await runComplianceAudit(getWorkspaceRoot(), pbiId);
@@ -345,6 +356,54 @@ describe('Compliance-audit operation (Issue 82 / RM-REQ-010/011/012/013)', () =>
       expect(getPbi(pbiId)?.auditTierIndex).toBe(0);
       expect(getPbi(pbiId)?.lastAuditHadFindings).toBe(false);
       expect(getPbi(pbiId)?.status).toBe('done');
+    });
+    it('does not escalate the tier or park the PBI when a repeat finding fires mid-cycle (remediation tasks still pending)', async () => {
+      // Regression test for the reviewer-flagged bug: shouldTriggerComplianceAudit's
+      // periodic trigger can re-run this audit while some of the prior cycle's
+      // remediation tasks are still pending. lastAuditHadFindings alone must not
+      // be treated as "a full remediation cycle completed and still failed".
+      const pbiId = 'pbi-midcycle-repeat';
+      const taskId = 'task-midcycle-repeat';
+      registerPbi(pbiId);
+      saveTask({
+        taskId, specId, specVersion: 'v1', title: 'Do work', description: null,
+        status: 'done', touches: null, dependsOn: null, branchName: `task/${taskId}`,
+        blockedReason: null, createdAt: Date.now(), updatedAt: Date.now(), pbiId,
+      });
+      await markPbiTaskDone(pbiId, taskId, 'incomplete work');
+
+      // First audit: finds an issue, creates a remediation task, tier stays at 0.
+      mockedExecuteAuditSession.mockResolvedValue({
+        pass: false,
+        findings: [{ title: 'Missing validation', description: 'Spec requires input validation.' }],
+      });
+      const first = await runComplianceAudit(getWorkspaceRoot(), pbiId);
+      expect(first.scenario).toBe('findings-first-pass');
+      expect(first.remediationTaskIds).toHaveLength(1);
+
+      // The remediation task from the first audit is still 'pending' -- the
+      // remediation cycle has NOT completed. Simulate a periodic re-trigger
+      // (e.g. an unrelated task on the same PBI merging) firing this audit
+      // again anyway, while that remediation task is still outstanding.
+      const pendingRemediationTask = getTasksForPbi(pbiId).find((t) => t.taskId !== taskId)!;
+      expect(pendingRemediationTask.status).toBe('pending');
+
+      mockedExecuteAuditSession.mockResolvedValue({
+        pass: false,
+        findings: [{ title: 'Missing validation', description: 'Spec requires input validation.' }],
+      });
+      const second = await runComplianceAudit(getWorkspaceRoot(), pbiId);
+
+      // Must NOT be treated as a genuine repeat failure: the remediation
+      // cycle from the first audit never actually finished.
+      expect(second.scenario).toBe('findings-first-pass');
+      expect(second.pbiParked).toBe(false);
+      expect(second.auditTierIndex).toBe(0);
+      expect(getPbi(pbiId)?.auditTierIndex).toBe(0);
+      expect(getPbi(pbiId)?.status).toBe('in_progress');
+
+      const secondCallConfig = (mockedExecuteAuditSession.mock.calls[1] as unknown[])[1] as { model: string };
+      expect(secondCallConfig.model).toBe('mock-model-tier-0');
     });
   });
 

--- a/src/test/compliance_audit.test.ts
+++ b/src/test/compliance_audit.test.ts
@@ -10,7 +10,10 @@ vi.mock('../utils/auditorHelper', async () => {
   const actual = await vi.importActual<typeof import('../utils/auditorHelper')>('../utils/auditorHelper');
   return {
     ...actual,
-    getAuditorExecutionConfig: () => ({ model: 'mock-model', provider: undefined }),
+    getAuditorExecutionConfig: (_apiKey?: string, tierIndex: number = 0) => ({
+      model: `mock-model-tier-${tierIndex}`,
+      provider: undefined,
+    }),
     executeAuditSession: vi.fn(),
   };
 });
@@ -176,6 +179,173 @@ describe('Compliance-audit operation (Issue 82 / RM-REQ-010/011/012/013)', () =>
     await expect(runComplianceAudit(getWorkspaceRoot(), pbiId)).rejects.toThrow(
       /did not return a proper submit_compliance_audit/
     );
+  });
+
+  describe('Tiered escalation for compliance-audit remediation (Issue 81 / RM-REQ-020/021/022)', () => {
+    function markPbiTaskDone(pbiId: string, taskId: string, content: string) {
+      // Helper mirroring the other tests' pattern: put a task's diff onto
+      // pbi/<pbiId> so runComplianceAudit has something to audit.
+      return (async () => {
+        const sandbox = getGitSandbox();
+        await sandbox.checkoutTaskBranch(taskId, pbiId);
+        fs.writeFileSync(path.join(getWorkspaceRoot(), `${taskId}-output.txt`), content, 'utf8');
+        await sandbox.commitAllChangesAsync(`Do work for ${taskId}`);
+        await sandbox.mergeTaskIntoPbi(taskId, pbiId);
+      })();
+    }
+
+    it('a first-time finding creates remediation tasks without escalating the audit tier', async () => {
+      const pbiId = 'pbi-first-finding';
+      const taskId = 'task-first-finding';
+      registerPbi(pbiId);
+      saveTask({
+        taskId, specId, specVersion: 'v1', title: 'Do work', description: null,
+        status: 'done', touches: null, dependsOn: null, branchName: `task/${taskId}`,
+        blockedReason: null, createdAt: Date.now(), updatedAt: Date.now(), pbiId,
+      });
+      await markPbiTaskDone(pbiId, taskId, 'incomplete work');
+
+      mockedExecuteAuditSession.mockResolvedValue({
+        pass: false,
+        findings: [{ title: 'Missing validation', description: 'Spec requires input validation.' }],
+      });
+
+      const result = await runComplianceAudit(getWorkspaceRoot(), pbiId);
+
+      expect(result.scenario).toBe('findings-first-pass');
+      expect(result.pbiParked).toBe(false);
+      expect(result.auditTierIndex).toBe(0);
+      expect(result.remediationTaskIds).toHaveLength(1);
+      expect(getPbi(pbiId)?.auditTierIndex).toBe(0);
+      expect(getPbi(pbiId)?.lastAuditHadFindings).toBe(true);
+      expect(getPbi(pbiId)?.status).toBe('in_progress');
+    });
+
+    it('escalates the audit tier when a repeat audit (after remediation) still finds issues', async () => {
+      const pbiId = 'pbi-repeat-finding';
+      const taskId = 'task-repeat-finding';
+      registerPbi(pbiId);
+      saveTask({
+        taskId, specId, specVersion: 'v1', title: 'Do work', description: null,
+        status: 'done', touches: null, dependsOn: null, branchName: `task/${taskId}`,
+        blockedReason: null, createdAt: Date.now(), updatedAt: Date.now(), pbiId,
+      });
+      await markPbiTaskDone(pbiId, taskId, 'incomplete work');
+
+      // First audit: finds an issue, tier stays at 0.
+      mockedExecuteAuditSession.mockResolvedValue({
+        pass: false,
+        findings: [{ title: 'Missing validation', description: 'Spec requires input validation.' }],
+      });
+      const first = await runComplianceAudit(getWorkspaceRoot(), pbiId);
+      expect(first.scenario).toBe('findings-first-pass');
+
+      // Simulate the remediation cycle completing and drifting further.
+      fs.writeFileSync(path.join(getWorkspaceRoot(), 'remediation-output.txt'), 'still incomplete', 'utf8');
+      await getGitSandbox().checkoutTaskBranch('remediation-cycle-branch', pbiId);
+      await getGitSandbox().commitAllChangesAsync('Remediation attempt');
+      await getGitSandbox().mergeTaskIntoPbi('remediation-cycle-branch', pbiId);
+
+      // Second (repeat) audit: still finds an issue -- must escalate tier.
+      mockedExecuteAuditSession.mockResolvedValue({
+        pass: false,
+        findings: [{ title: 'Still missing validation', description: 'Remediation did not fix it.' }],
+      });
+      const second = await runComplianceAudit(getWorkspaceRoot(), pbiId);
+
+      expect(second.scenario).toBe('findings-audit-escalated');
+      expect(second.auditTierIndex).toBe(1);
+      expect(second.pbiParked).toBe(false);
+      expect(second.remediationTaskIds).toHaveLength(1);
+      expect(getPbi(pbiId)?.auditTierIndex).toBe(1);
+      expect(getPbi(pbiId)?.status).toBe('in_progress');
+
+      // The repeat-failure audit itself runs at the *still-current* tier
+      // (tier can only be known to need escalation after seeing this
+      // result) -- the escalated tier takes effect starting with the next
+      // audit run for this PBI, which is what result.auditTierIndex (and
+      // the persisted PBI record) reflect going forward.
+      const firstCallConfig = (mockedExecuteAuditSession.mock.calls[0] as unknown[])[1] as { model: string };
+      const secondCallConfig = (mockedExecuteAuditSession.mock.calls[1] as unknown[])[1] as { model: string };
+      expect(secondCallConfig.model).toBe(firstCallConfig.model);
+      expect(secondCallConfig.model).toBe('mock-model-tier-0');
+
+      // A third audit run (after the tier-1 remediation cycle completes)
+      // must actually use the escalated tier.
+      fs.writeFileSync(path.join(getWorkspaceRoot(), 'remediation-2-output.txt'), 'yet another attempt', 'utf8');
+      await getGitSandbox().checkoutTaskBranch('remediation-cycle-branch-2', pbiId);
+      await getGitSandbox().commitAllChangesAsync('Second remediation attempt');
+      await getGitSandbox().mergeTaskIntoPbi('remediation-cycle-branch-2', pbiId);
+
+      mockedExecuteAuditSession.mockResolvedValue({ pass: true, findings: [] });
+      await runComplianceAudit(getWorkspaceRoot(), pbiId);
+
+      const thirdCallConfig = (mockedExecuteAuditSession.mock.calls[2] as unknown[])[1] as { model: string };
+      expect(thirdCallConfig.model).toBe('mock-model-tier-1');
+    });
+
+    it('parks the entire PBI when the highest audit tier still finds issues after a full remediation cycle', async () => {
+      const pbiId = 'pbi-parked';
+      const taskId = 'task-parked';
+      registerPbi(pbiId);
+      saveTask({
+        taskId, specId, specVersion: 'v1', title: 'Do work', description: null,
+        status: 'done', touches: null, dependsOn: null, branchName: `task/${taskId}`,
+        blockedReason: null, createdAt: Date.now(), updatedAt: Date.now(), pbiId,
+      });
+      await markPbiTaskDone(pbiId, taskId, 'incomplete work');
+
+      // Force the PBI to already be at the highest audit tier, mid-cycle
+      // (a prior audit already found something and remediation ran).
+      const maxTierPbi = getPbi(pbiId)!;
+      savePbi({
+        ...maxTierPbi,
+        auditTierIndex: 2, // highest configured tier (0, 1, 2)
+        lastAuditHadFindings: true,
+      });
+
+      mockedExecuteAuditSession.mockResolvedValue({
+        pass: false,
+        findings: [{ title: 'Persistent issue', description: 'Still broken at the top tier.' }],
+      });
+
+      const result = await runComplianceAudit(getWorkspaceRoot(), pbiId);
+
+      expect(result.scenario).toBe('findings-pbi-parked');
+      expect(result.pbiParked).toBe(true);
+      expect(result.remediationTaskIds).toHaveLength(0);
+      expect(getPbi(pbiId)?.status).toBe('blocked');
+      expect(getPbi(pbiId)?.auditTierIndex).toBe(2);
+
+      // No further remediation tasks were spun up for a parked PBI.
+      const tasks = getTasksForPbi(pbiId).filter((t) => t.taskId !== taskId);
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('resets the audit tier back to 0 on a subsequent clean pass', async () => {
+      const pbiId = 'pbi-reset-on-clean';
+      const taskId = 'task-reset-on-clean';
+      registerPbi(pbiId);
+      saveTask({
+        taskId, specId, specVersion: 'v1', title: 'Do work', description: null,
+        status: 'done', touches: null, dependsOn: null, branchName: `task/${taskId}`,
+        blockedReason: null, createdAt: Date.now(), updatedAt: Date.now(), pbiId,
+      });
+      await markPbiTaskDone(pbiId, taskId, 'work');
+
+      const escalatedPbi = getPbi(pbiId)!;
+      savePbi({ ...escalatedPbi, auditTierIndex: 1, lastAuditHadFindings: true });
+
+      mockedExecuteAuditSession.mockResolvedValue({ pass: true, findings: [] });
+
+      const result = await runComplianceAudit(getWorkspaceRoot(), pbiId);
+
+      expect(result.scenario).toBe('clean');
+      expect(result.auditTierIndex).toBe(0);
+      expect(getPbi(pbiId)?.auditTierIndex).toBe(0);
+      expect(getPbi(pbiId)?.lastAuditHadFindings).toBe(false);
+      expect(getPbi(pbiId)?.status).toBe('done');
+    });
   });
 
   describe('shouldTriggerComplianceAudit (RM-REQ-011/012)', () => {

--- a/src/utils/auditorHelper.ts
+++ b/src/utils/auditorHelper.ts
@@ -1,7 +1,7 @@
 import { runForcedToolTurn } from './toolCallEnforcement';
 import { CopilotClient, SdkProviderConfig, SessionConfig, CopilotSession, PermissionRequest, PermissionRequestResult } from '../copilotSdk/boundary';
 import { ProviderRegistry, ExecutionConfig } from './providerRegistry';
-import { DEFAULT_ROLES_CONFIG } from '../config/models';
+import { DEFAULT_ROLES_CONFIG, getAuditorTierConfig } from '../config/models';
 
 export interface ToolDefinition {
   readonly function: {
@@ -30,9 +30,14 @@ export interface ResponseRequirement {
 /**
  * Shared logic to resolve the auditor's execution configuration via ProviderRegistry.
  * Ensures both auditors respect DEFAULT_ROLES_CONFIG.auditor.provider. * Throws a loud error if no API key is available for the required provider.
+ *
+ * `tierIndex` selects a rung on the auditor escalation ladder (Issue 81 /
+ * RM-REQ-021), defaulting to tier 0 -- the same single-tier config this
+ * function always resolved before the ladder existed, so existing callers
+ * (e.g. the per-task Spec-Gate Auditor) are unaffected.
  */
-export function getAuditorExecutionConfig(apiKey?: string): ExecutionConfig {
-  const auditorConfig = DEFAULT_ROLES_CONFIG.auditor;
+export function getAuditorExecutionConfig(apiKey?: string, tierIndex: number = 0): ExecutionConfig {
+  const auditorConfig = getAuditorTierConfig(tierIndex);
   const provider = auditorConfig.provider;
   // Resolve the key based on the provider
   let keyToUse = apiKey;


### PR DESCRIPTION
## Overview
Implement a tiered escalation policy for remediation tasks created by compliance audits. Audits themselves can be escalated if repeated audits after remediation still report findings.

## Requirements
- RM-REQ-020, RM-REQ-021, RM-REQ-022

## Acceptance Criteria
- [ ] Remediation tasks reuse existing tiered escalation ladder from `gateLoop.ts`:
  - Retry same model → escalate model tier → park with async notification
- [ ] Repeated audit failures escalate the *audit's own model tier* before creating further remediation tasks
- [ ] Highest-tier persistent failure after full remediation cycle:
  - Parks the entire PBI (not just individual tasks)
  - Raises async human escalation
- [ ] Escalation entries distinguish between different remediation scenarios

## Details
This escalation policy mirrors the ordinary task escalation ladder but applies it bidirectionally:
1. Remediation tasks created by audit follow normal task escalation (retry/tier/park)
2. If a remediation cycle completes but the next audit still finds issues, escalate the audit itself
3. If the highest-tier auditor still finds issues after a full remediation cycle, park the PBI and notify humans

## Dependencies
- **Blocked by:** Issue 8 (Full-PBI compliance audit operation)