### PR TITLE
Issue 80: dependency-blocked PBI escalation (cross-PBI) (#132)

### DIFF
--- a/src/gates/pbiDependencyGate.ts
+++ b/src/gates/pbiDependencyGate.ts
@@ -139,6 +139,13 @@ export function checkPbiDependencies(pbiId: string): PbiStartEligibility {
 
   const dependsOn: string[] = pbi.dependsOn ? JSON.parse(pbi.dependsOn) : [];
 
+  // Two-pass scan, not a single early-return loop: a `blocked` dependency
+  // must take priority over a merely-pending one regardless of array order.
+  // (A single-pass loop that returns on the first non-done dependency it
+  // sees would miss a blocked dependency listed after a pending one --
+  // order-dependent behavior that silently skips parking + escalation.)
+  let waitingOnPbiId: string | undefined;
+
   for (const depId of dependsOn) {
     const dep: PbiRecord | undefined = getPbi(depId);
     if (!dep || dep.status === 'done') {
@@ -153,8 +160,16 @@ export function checkPbiDependencies(pbiId: string): PbiStartEligibility {
       return { canStart: false, reason: 'blocked-by-dependency', dependencyPbiId: depId };
     }
 
-    // pending or in_progress: ordinary "not ready yet" -- no escalation.
-    return { canStart: false, reason: 'waiting-on-dependency', dependencyPbiId: depId };
+    // pending or in_progress: ordinary "not ready yet" -- keep scanning in
+    // case a later dependency is actually blocked, but remember this one in
+    // case none are.
+    if (!waitingOnPbiId) {
+      waitingOnPbiId = depId;
+    }
+  }
+
+  if (waitingOnPbiId) {
+    return { canStart: false, reason: 'waiting-on-dependency', dependencyPbiId: waitingOnPbiId };
   }
 
   return { canStart: true };

--- a/src/gates/pbiDependencyGate.ts
+++ b/src/gates/pbiDependencyGate.ts
@@ -1,0 +1,161 @@
+import { getPbi, getPbisForSpec, savePbi, PbiRecord } from '../db/pbiStore';
+import { appendEscalation, getPendingEscalation } from '../utils/escalationStore';
+
+/**
+ * Dependency-blocked PBI escalation (Issue 80 / RM-REQ-060/061/062).
+ *
+ * Before starting work on a PBI, its `dependsOn` edges must be checked: if
+ * any dependency is itself `blocked`, this PBI cannot proceed either. Rather
+ * than silently stalling, it is parked (status: 'blocked') and a single
+ * async escalation is raised describing the *impact* of the blocking PBI --
+ * how many other PBIs (directly and transitively) are stuck behind it -- so
+ * humans can prioritize resolving high-impact blockers first.
+ */
+
+function synthesizeSessionId(blockedPbiId: string): string {
+  // No real agent session exists yet for a PBI that hasn't started -- use a
+  // deterministic pseudo-session id scoped to the blocked PBI so
+  // getPendingEscalation can dedupe repeated checks into a single entry
+  // (RM-REQ-061: "raise a single async escalation").
+  return `pbi-dependency-blocked:${blockedPbiId}`;
+}
+
+export interface DependentImpact {
+  /** PBIs whose dependsOn directly references the blocked PBI. */
+  readonly direct: number;
+  /** Full dependency-graph walk: all PBIs (direct + indirect) stuck behind the blocked PBI. */
+  readonly transitive: number;
+}
+
+/**
+ * Walks the persisted PBI graph for `specId` (dependsOn edges only ever
+ * reference PBIs within the same spec/batch -- see pbiDerivation.ts) and
+ * computes how many PBIs are stuck behind `blockedPbiId`, directly and
+ * transitively.
+ */
+export function computeDependentImpact(blockedPbiId: string, specId: string): DependentImpact {
+  const allPbis = getPbisForSpec(specId);
+
+  // dependentsOf.get(x) = pbiIds that directly list x in their dependsOn.
+  const dependentsOf = new Map<string, string[]>();
+  for (const p of allPbis) {
+    const deps: string[] = p.dependsOn ? JSON.parse(p.dependsOn) : [];
+    for (const depId of deps) {
+      if (!dependentsOf.has(depId)) {
+        dependentsOf.set(depId, []);
+      }
+      dependentsOf.get(depId)!.push(p.pbiId);
+    }
+  }
+
+  const direct = dependentsOf.get(blockedPbiId) ?? [];
+
+  // Full graph walk: BFS outward from the direct dependents, following
+  // "who depends on this PBI" edges, to find every PBI stuck behind
+  // blockedPbiId (directly or through a chain of dependencies).
+  const visited = new Set<string>();
+  const queue = [...direct];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    const next = dependentsOf.get(current) ?? [];
+    queue.push(...next);
+  }
+
+  return { direct: direct.length, transitive: visited.size };
+}
+
+export interface DependencyBlockedEscalationResult {
+  readonly raised: boolean;
+  readonly impact: DependentImpact;
+}
+
+/**
+ * Raises a single async human escalation for a blocked PBI, describing its
+ * downstream impact (RM-REQ-061/062). No-ops (does not raise) when:
+ * - the PBI has no dependents at all (a leaf blocked PBI with nothing
+ *   waiting on it -- parking is a valid resting state, not an incident), or
+ * - an escalation for this exact blocked PBI is already pending (dedupe --
+ *   "a single async escalation", not one per dependency-check).
+ */
+export function raiseDependencyBlockedEscalation(blockedPbiId: string): DependencyBlockedEscalationResult {
+  const blockedPbi = getPbi(blockedPbiId);
+  if (!blockedPbi) {
+    throw new Error(`No PBI found for pbiId "${blockedPbiId}".`);
+  }
+
+  const impact = computeDependentImpact(blockedPbiId, blockedPbi.specId);
+
+  if (impact.direct === 0 && impact.transitive === 0) {
+    // Leaf blocked PBI with no dependents -- not an incident.
+    return { raised: false, impact };
+  }
+
+  const sessionId = synthesizeSessionId(blockedPbiId);
+  if (getPendingEscalation(sessionId)) {
+    // Already raised and still pending -- keep this a single escalation.
+    return { raised: false, impact };
+  }
+
+  appendEscalation({
+    sessionId,
+    summary:
+      `pbi/${blockedPbiId} ("${blockedPbi.title}") is blocked and has ${impact.direct} PBI(s) directly ` +
+      `depending on it (${impact.transitive} total across the full dependency graph). Resolving this blocker ` +
+      `unblocks downstream work -- prioritize accordingly.`,
+    failedGate: 'pbi-dependency-blocked',
+    failedGateFeedback: JSON.stringify({ blockedPbiId, ...impact }),
+    retryHistory: [],
+  });
+
+  return { raised: true, impact };
+}
+
+export type PbiStartEligibility =
+  | { readonly canStart: true }
+  | { readonly canStart: false; readonly reason: 'waiting-on-dependency'; readonly dependencyPbiId: string }
+  | { readonly canStart: false; readonly reason: 'blocked-by-dependency'; readonly dependencyPbiId: string };
+
+/**
+ * PBI-selection logic (RM-REQ-060): checks `dependsOn` status before a PBI
+ * may start work.
+ *
+ * - If every dependency is `done` (or there are none), the PBI may start.
+ * - If a dependency exists but simply hasn't finished yet (pending/
+ *   in_progress), the PBI must wait -- this is normal scheduling, not an
+ *   incident, so no escalation and no status change.
+ * - If a dependency is itself `blocked`, this PBI cannot proceed: it is
+ *   parked (status set to 'blocked') and a dependency-blocked escalation is
+ *   raised for the blocking PBI (RM-REQ-061/062).
+ */
+export function checkPbiDependencies(pbiId: string): PbiStartEligibility {
+  const pbi = getPbi(pbiId);
+  if (!pbi) {
+    throw new Error(`No PBI found for pbiId "${pbiId}".`);
+  }
+
+  const dependsOn: string[] = pbi.dependsOn ? JSON.parse(pbi.dependsOn) : [];
+
+  for (const depId of dependsOn) {
+    const dep: PbiRecord | undefined = getPbi(depId);
+    if (!dep || dep.status === 'done') {
+      continue;
+    }
+
+    if (dep.status === 'blocked') {
+      if (pbi.status !== 'blocked') {
+        savePbi({ ...pbi, status: 'blocked', updatedAt: Date.now() });
+      }
+      raiseDependencyBlockedEscalation(depId);
+      return { canStart: false, reason: 'blocked-by-dependency', dependencyPbiId: depId };
+    }
+
+    // pending or in_progress: ordinary "not ready yet" -- no escalation.
+    return { canStart: false, reason: 'waiting-on-dependency', dependencyPbiId: depId };
+  }
+
+  return { canStart: true };
+}

--- a/src/test/pbi_dependency_gate.test.ts
+++ b/src/test/pbi_dependency_gate.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import { db } from '../db/index';
+import { saveSpec } from '../db/taskStore';
+import { savePbi, getPbi, PbiRecord } from '../db/pbiStore';
+import { getEscalations } from '../utils/escalationStore';
+import {
+  checkPbiDependencies,
+  computeDependentImpact,
+  raiseDependencyBlockedEscalation,
+} from '../gates/pbiDependencyGate';
+
+describe('Dependency-blocked PBI escalation (Issue 80 / RM-REQ-060/061/062)', () => {
+  const specId = 'spec-dep-gate-test';
+
+  beforeEach(() => {
+    db.prepare('DELETE FROM tasks').run();
+    db.prepare('DELETE FROM pbis').run();
+    db.prepare('DELETE FROM specs').run();
+    db.prepare('DELETE FROM escalations').run();
+    saveSpec({ specId, filePath: 'architecture-spec.md', version: 'v1', createdAt: Date.now() });
+  });
+
+  function makePbi(pbiId: string, status: PbiRecord['status'], dependsOn: string[] | null): PbiRecord {
+    return {
+      pbiId,
+      specId,
+      title: `Title for ${pbiId}`,
+      description: null,
+      status,
+      dependsOn: dependsOn ? JSON.stringify(dependsOn) : null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+  }
+
+  describe('checkPbiDependencies (RM-REQ-060)', () => {
+    it('throws when the pbiId does not exist', () => {
+      expect(() => checkPbiDependencies('pbi-does-not-exist')).toThrow(/No PBI found/);
+    });
+
+    it('allows starting when there are no dependencies', () => {
+      savePbi(makePbi('pbi-a', 'pending', null));
+      expect(checkPbiDependencies('pbi-a')).toEqual({ canStart: true });
+    });
+
+    it('allows starting when all dependencies are done', () => {
+      savePbi(makePbi('pbi-a', 'done', null));
+      savePbi(makePbi('pbi-b', 'pending', ['pbi-a']));
+      expect(checkPbiDependencies('pbi-b')).toEqual({ canStart: true });
+    });
+
+    it('waits (no escalation, no status change) when a dependency is merely pending/in_progress', () => {
+      savePbi(makePbi('pbi-a', 'in_progress', null));
+      savePbi(makePbi('pbi-b', 'pending', ['pbi-a']));
+
+      const result = checkPbiDependencies('pbi-b');
+
+      expect(result).toEqual({ canStart: false, reason: 'waiting-on-dependency', dependencyPbiId: 'pbi-a' });
+      expect(getPbi('pbi-b')?.status).toBe('pending'); // not parked
+      expect(getEscalations()).toHaveLength(0);
+    });
+
+    it('parks the PBI and raises escalation when a dependency is blocked', () => {
+      savePbi(makePbi('pbi-a', 'blocked', null));
+      savePbi(makePbi('pbi-b', 'pending', ['pbi-a']));
+
+      const result = checkPbiDependencies('pbi-b');
+
+      expect(result).toEqual({ canStart: false, reason: 'blocked-by-dependency', dependencyPbiId: 'pbi-a' });
+      expect(getPbi('pbi-b')?.status).toBe('blocked');
+
+      const escalations = getEscalations();
+      expect(escalations).toHaveLength(1);
+      expect(escalations[0]?.failedGate).toBe('pbi-dependency-blocked');
+      expect(escalations[0]?.summary).toContain('pbi-a');
+    });
+
+    it('does not re-park an already-blocked PBI, but still checks escalation dedupe', () => {
+      savePbi(makePbi('pbi-a', 'blocked', null));
+      savePbi(makePbi('pbi-b', 'blocked', ['pbi-a']));
+
+      checkPbiDependencies('pbi-b');
+      checkPbiDependencies('pbi-b');
+
+      // Still just one pending escalation despite two checks (RM-REQ-061: "a single async escalation").
+      expect(getEscalations()).toHaveLength(1);
+    });
+  });
+
+  describe('computeDependentImpact (full dependency-graph walk)', () => {
+    it('returns zero for a leaf PBI with no dependents', () => {
+      savePbi(makePbi('pbi-leaf', 'blocked', null));
+      expect(computeDependentImpact('pbi-leaf', specId)).toEqual({ direct: 0, transitive: 0 });
+    });
+
+    it('counts only direct dependents when there is no deeper chain', () => {
+      savePbi(makePbi('pbi-a', 'blocked', null));
+      savePbi(makePbi('pbi-b', 'pending', ['pbi-a']));
+      savePbi(makePbi('pbi-c', 'pending', ['pbi-a']));
+      expect(computeDependentImpact('pbi-a', specId)).toEqual({ direct: 2, transitive: 2 });
+    });
+
+    it('walks the full transitive chain (direct dependents plus their dependents)', () => {
+      // a <- b <- c <- d  (b, c, d all depend transitively on a)
+      savePbi(makePbi('pbi-a', 'blocked', null));
+      savePbi(makePbi('pbi-b', 'pending', ['pbi-a']));
+      savePbi(makePbi('pbi-c', 'pending', ['pbi-b']));
+      savePbi(makePbi('pbi-d', 'pending', ['pbi-c']));
+      expect(computeDependentImpact('pbi-a', specId)).toEqual({ direct: 1, transitive: 3 });
+    });
+
+    it('deduplicates diamond-shaped dependency graphs', () => {
+      //   a <- b <- d
+      //   a <- c <- d
+      savePbi(makePbi('pbi-a', 'blocked', null));
+      savePbi(makePbi('pbi-b', 'pending', ['pbi-a']));
+      savePbi(makePbi('pbi-c', 'pending', ['pbi-a']));
+      savePbi(makePbi('pbi-d', 'pending', ['pbi-b', 'pbi-c']));
+      expect(computeDependentImpact('pbi-a', specId)).toEqual({ direct: 2, transitive: 3 });
+    });
+  });
+
+  describe('raiseDependencyBlockedEscalation (RM-REQ-061/062)', () => {
+    it('throws when the pbiId does not exist', () => {
+      expect(() => raiseDependencyBlockedEscalation('pbi-does-not-exist')).toThrow(/No PBI found/);
+    });
+
+    it('does not raise an escalation for a leaf blocked PBI with no dependents', () => {
+      savePbi(makePbi('pbi-leaf', 'blocked', null));
+
+      const result = raiseDependencyBlockedEscalation('pbi-leaf');
+
+      expect(result.raised).toBe(false);
+      expect(result.impact).toEqual({ direct: 0, transitive: 0 });
+      expect(getEscalations()).toHaveLength(0);
+    });
+
+    it('raises a single escalation including direct and transitive impact metrics', () => {
+      savePbi(makePbi('pbi-a', 'blocked', null));
+      savePbi(makePbi('pbi-b', 'pending', ['pbi-a']));
+      savePbi(makePbi('pbi-c', 'pending', ['pbi-b']));
+
+      const result = raiseDependencyBlockedEscalation('pbi-a');
+
+      expect(result.raised).toBe(true);
+      expect(result.impact).toEqual({ direct: 1, transitive: 2 });
+
+      const escalations = getEscalations();
+      expect(escalations).toHaveLength(1);
+      const feedback = JSON.parse(escalations[0]!.failedGateFeedback!);
+      expect(feedback).toEqual({ blockedPbiId: 'pbi-a', direct: 1, transitive: 2 });
+    });
+
+    it('does not raise a second escalation while one is already pending for the same blocked PBI', () => {
+      savePbi(makePbi('pbi-a', 'blocked', null));
+      savePbi(makePbi('pbi-b', 'pending', ['pbi-a']));
+
+      const first = raiseDependencyBlockedEscalation('pbi-a');
+      const second = raiseDependencyBlockedEscalation('pbi-a');
+
+      expect(first.raised).toBe(true);
+      expect(second.raised).toBe(false);
+      expect(getEscalations()).toHaveLength(1);
+    });
+  });
+});

--- a/src/test/pbi_dependency_gate.test.ts
+++ b/src/test/pbi_dependency_gate.test.ts
@@ -13,6 +13,7 @@ describe('Dependency-blocked PBI escalation (Issue 80 / RM-REQ-060/061/062)', ()
   const specId = 'spec-dep-gate-test';
 
   beforeEach(() => {
+    db.prepare('DELETE FROM sessions').run();
     db.prepare('DELETE FROM tasks').run();
     db.prepare('DELETE FROM pbis').run();
     db.prepare('DELETE FROM specs').run();
@@ -84,6 +85,28 @@ describe('Dependency-blocked PBI escalation (Issue 80 / RM-REQ-060/061/062)', ()
 
       // Still just one pending escalation despite two checks (RM-REQ-061: "a single async escalation").
       expect(getEscalations()).toHaveLength(1);
+    });
+
+    it('detects a blocked dependency even when it is listed after a merely-pending one (regression)', () => {
+      // Order-dependent bug regression: a single-pass loop that returns on
+      // the FIRST non-done dependency would stop at pbi-pending and never
+      // reach pbi-blocked-dep, silently skipping the park + escalation.
+      savePbi(makePbi('pbi-pending', 'in_progress', null));
+      savePbi(makePbi('pbi-blocked-dep', 'blocked', null));
+      savePbi(makePbi('pbi-c', 'pending', ['pbi-pending', 'pbi-blocked-dep']));
+
+      const result = checkPbiDependencies('pbi-c');
+
+      expect(result).toEqual({
+        canStart: false,
+        reason: 'blocked-by-dependency',
+        dependencyPbiId: 'pbi-blocked-dep',
+      });
+      expect(getPbi('pbi-c')?.status).toBe('blocked');
+
+      const escalations = getEscalations();
+      expect(escalations).toHaveLength(1);
+      expect(escalations[0]?.summary).toContain('pbi-blocked-dep');
     });
   });
 


### PR DESCRIPTION
## Overview
Implement escalation logic for PBIs blocked by their dependencies. When a PBI cannot start because its `dependsOn` references a blocked PBI, park it and raise a single async escalation with impact metrics.

## Requirements
- RM-REQ-060, RM-REQ-061, RM-REQ-062

## Acceptance Criteria
- [ ] PBI-selection logic checks `dependsOn` status before starting work
- [ ] Escalation entry created when a PBI is blocked by a dependency in `blocked` status
- [ ] Escalation entry includes:
  - Direct count of PBIs depending on the blocked PBI
  - Transitive count (full dependency graph walk over persisted PBIs)
- [ ] No escalation fires for a leaf blocked PBI with no dependents (parking is a valid resting state)

## Details
A blocked PBI with downstream PBIs depending on it creates an escalation to notify humans of the impact. A blocked PBI with nothing depending on it does *not* trigger escalation — blocking is a valid state in that case.

The escalation entry allows the work queue to be sorted by downstream impact, prioritizing resolution of blockers that affect many other PBIs.

## Dependencies
- **Blocked by:** Issue 1 (Introduce PBI tier), Issue 3 (PBI derivation — PBI graph must exist)