### PR TITLE
Issue 79: auditor model rotation pool

### DIFF
--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -25,6 +25,7 @@ export interface SystemRolesConfig {
   readonly executorTiers: readonly ModelProviderConfig[]; // Tiered ladder for execution
   readonly auditor: ModelProviderConfig;
   readonly auditorTiers: readonly ModelProviderConfig[]; // Tiered escalation ladder for the compliance-audit operation (Issue 81)
+  readonly auditorPool: readonly ModelProviderConfig[]; // Round-robin rotation pool for the general auditor role (Issue 79)
   readonly reviewer: ModelProviderConfig;
 }
 
@@ -163,6 +164,25 @@ export const DEFAULT_ROLES_CONFIG: SystemRolesConfig = {
       },
     ];
   },
+  /**
+   * Round-robin rotation pool for the general auditor role (Issue 79 /
+   * RM-REQ-030/031/032/033). Configured via a single `AUDITOR_POOL` env var
+   * of comma-separated `provider:model` entries, e.g.
+   * `AUDITOR_POOL=gemini:gemini-3.1-flash-lite,gemini:gemini-3.5-flash`.
+   * Falls back to a single-entry pool (this.auditor) when unset -- this is
+   * deliberately a single-model pool by default so the "single-model pool"
+   * warning (RM-REQ-032) surfaces until an operator opts into a real pool,
+   * rather than silently picking a diverse default nobody asked for.
+   *
+   * This pool is entirely independent of auditorTiers above: auditorTiers
+   * is the compliance-audit operation's own escalation ladder (Issue 81)
+   * and must not be conflated with this rotation pool (RM-REQ-033).
+   */
+  get auditorPool(): readonly ModelProviderConfig[] {
+    const raw = typeof process !== "undefined" ? process.env?.AUDITOR_POOL : undefined;
+    const parsed = parseAuditorPoolEnv(raw);
+    return parsed && parsed.length > 0 ? parsed : [this.auditor];
+  },
   get reviewer() {
     return {
       provider:
@@ -223,4 +243,59 @@ export function getAuditorTierConfig(tierIndex: number): ModelProviderConfig {
 /** Highest valid auditor tier index -- reaching this and still failing is a terminal escalation (RM-REQ-022). */
 export function getAuditorMaxTierIndex(): number {
   return DEFAULT_ROLES_CONFIG.auditorTiers.length - 1;
+}
+
+/**
+ * Parses the `AUDITOR_POOL` env var into a list of ModelProviderConfig
+ * entries (Issue 79 / RM-REQ-030). Expected format is comma-separated
+ * `provider:model` pairs, e.g.
+ * `"gemini:gemini-3.1-flash-lite,openai:gpt-4o-mini"`.
+ * Returns `null` (not an empty array) when `raw` is unset/blank so callers
+ * can distinguish "not configured" from "configured but empty" and fall
+ * back appropriately. Malformed entries (missing `:`, unknown provider) are
+ * skipped with a console warning rather than throwing, so a single typo in
+ * a long pool string doesn't take down the whole system.
+ */
+export function parseAuditorPoolEnv(raw: string | undefined): ModelProviderConfig[] | null {
+  if (!raw || !raw.trim()) {
+    return null;
+  }
+  const entries = raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  const pool: ModelProviderConfig[] = [];
+  for (const entry of entries) {
+    const separatorIndex = entry.indexOf(":");
+    if (separatorIndex === -1) {
+      console.warn(`[AUDITOR_POOL] Skipping malformed entry (expected "provider:model"): "${entry}"`);
+      continue;
+    }
+    const provider = entry.slice(0, separatorIndex).trim();
+    const model = entry.slice(separatorIndex + 1).trim();
+    if (!isProviderType(provider) || !model) {
+      console.warn(`[AUDITOR_POOL] Skipping malformed entry (unknown provider or empty model): "${entry}"`);
+      continue;
+    }
+    pool.push({ provider, model });
+  }
+  return pool;
+}
+
+/**
+ * Deterministic round-robin selection from the auditor pool (RM-REQ-031):
+ * `rotationIndex` is expected to be a monotonically increasing counter
+ * persisted in session state (see StateSnapshot.auditorRotationIndex) --
+ * this function itself is pure and does not mutate or persist anything.
+ * Negative indices wrap correctly (rather than throwing) purely as a
+ * defensive measure; callers should never pass a negative rotationIndex.
+ */
+export function selectFromAuditorPool(rotationIndex: number): ModelProviderConfig {
+  const pool = DEFAULT_ROLES_CONFIG.auditorPool;
+  if (pool.length === 0) {
+    throw new Error("Auditor pool is empty");
+  }
+  const normalizedIndex = ((rotationIndex % pool.length) + pool.length) % pool.length;
+  return pool[normalizedIndex]!;
 }

--- a/src/gates/specAuditor.ts
+++ b/src/gates/specAuditor.ts
@@ -1,4 +1,5 @@
 import { getAuditorExecutionConfig, executeAuditSession } from '../utils/auditorHelper';
+import { ExecutionConfig } from '../utils/providerRegistry';
 import { submitSpecAuditTool } from '../config/tools';
 import { getGitSandbox, getExecCommand } from '../workspace';
 
@@ -8,9 +9,19 @@ interface SpecAuditResult {
   readonly violation_type?: string;
 }
 
-export async function runSpecAudit(cwd: string, abortSignal?: AbortSignal): Promise<{ pass: boolean; feedback: string }> {
+/**
+ * `executionConfigOverride` lets callers supply a pre-resolved
+ * ExecutionConfig (e.g. from the Issue 79 auditor rotation pool) instead of
+ * the single-tier default -- when omitted, behavior is unchanged from
+ * before the rotation pool existed.
+ */
+export async function runSpecAudit(
+  cwd: string,
+  abortSignal?: AbortSignal,
+  executionConfigOverride?: ExecutionConfig,
+): Promise<{ pass: boolean; feedback: string }> {
   const targetCwd = cwd;
-  const executionConfig = getAuditorExecutionConfig();
+  const executionConfig = executionConfigOverride ?? getAuditorExecutionConfig();
   try {
     console.log('[runSpecAudit] Start git diff async...');
     // 1. Get git diff against active container sandbox worktree

--- a/src/orchestrator/gateLoop.ts
+++ b/src/orchestrator/gateLoop.ts
@@ -51,6 +51,7 @@ import {
 } from "../config/gates";
 import { runSpecAudit } from "../gates/specAuditor";
 import { runComplianceAudit, shouldTriggerComplianceAudit } from "../gates/complianceAudit";
+import { selectRotatingAuditorConfig } from "../utils/auditorHelper";
 import { validateCwd } from "../security/pathGuard";
 import { sanitizeSensitives } from "../utils/sanitizers";
 import { truncateOutput } from "../utils/formatters";
@@ -431,6 +432,51 @@ export const activeBackgroundRuns = new Map<
     promise: Promise<void>;
   }
 >();
+
+/**
+ * Issue 79 / RM-REQ-030/031/032: pulls the current rotation index out of
+ * this session's persisted state, selects the next auditor from the pool,
+ * advances and persists the rotation index for next time, and logs the two
+ * required (non-blocking) warnings:
+ * - the configured pool has only one model (no real rotation possible), or
+ * - the selected auditor happens to match the Implementor's model for this
+ *   task (reduced decorrelation between "writer" and "checker").
+ *
+ * Deliberately independent of the compliance-audit tiering mechanism
+ * (Issue 81 / RM-REQ-021) -- that operation calls getAuditorExecutionConfig
+ * with a tierIndex directly and never goes through this rotation pool.
+ */
+function selectAndAdvanceAuditorRotation(
+  sessionId: string | undefined,
+  implementorModel: string | undefined,
+  apiKey: string | undefined,
+) {
+  const currentIndex = sessionId
+    ? (activeSessions.get(sessionId)?.stateSnapshot?.auditorRotationIndex ?? 0)
+    : 0;
+  const selection = selectRotatingAuditorConfig(currentIndex, apiKey);
+
+  if (selection.singleModelPool) {
+    writeLog(
+      `[GateLoop] Auditor pool has only a single model configured (${selection.executionConfig.model}); ` +
+      `no rotation is actually occurring. Configure AUDITOR_POOL with multiple models for real decorrelation.`,
+      LogLevel.WARN,
+    );
+  }
+  if (implementorModel && selection.executionConfig.model === implementorModel) {
+    writeLog(
+      `[GateLoop] Selected auditor model (${selection.executionConfig.model}) matches the Implementor's model ` +
+      `for this task; decorrelation between implementor and auditor is reduced for this attempt.`,
+      LogLevel.WARN,
+    );
+  }
+
+  if (sessionId) {
+    updateStateSnapshot(sessionId, { auditorRotationIndex: selection.nextRotationIndex });
+  }
+
+  return selection;
+}
 
 export const handleGateLoop = async (
   req: express.Request,
@@ -2394,11 +2440,17 @@ export const handleGateLoop = async (
                 } else if (gateName === "runAudit") {
                   const startAuditTime = Date.now();
                   const currentCodeState = await getCodeState(runCwd);
+                  const rotatingAuditorSelection = selectAndAdvanceAuditorRotation(
+                    sessionId,
+                    currentModel,
+                    keyToUse,
+                  );
                   const auditPayload = await runLlmAudit(
                     promptStr,
                     currentCodeState,
                     keyToUse,
                     abortController.signal,
+                    rotatingAuditorSelection.executionConfig,
                   );
                   const loopPassed = auditPayload.pass;
 
@@ -2620,9 +2672,15 @@ export const handleGateLoop = async (
                 isRequestClosed,
               );
 
+              const rotatingSpecAuditorSelection = selectAndAdvanceAuditorRotation(
+                sessionId,
+                currentModel,
+                keyToUse,
+              );
               const specResult = await runSpecAudit(
                 runCwd,
                 abortController.signal,
+                rotatingSpecAuditorSelection.executionConfig,
               );
               updateStateSnapshot(sessionId, {
                 activeGate: undefined,

--- a/src/orchestrator/sessionState.ts
+++ b/src/orchestrator/sessionState.ts
@@ -9,6 +9,7 @@ import { getWorkspaceHostLocation, getExecCommand, getWorkspaceRoot } from '../w
 import { checkPathInside } from '../security/pathGuard';
 import { saveSession, deleteSession, getSession } from '../db/sessionStore';
 import { getAuditorExecutionConfig, executeAuditSession } from '../utils/auditorHelper';
+import { ExecutionConfig } from '../utils/providerRegistry';
 import { submitAuditFindingsTool } from '../config/tools';
 
 export interface CopilotCreateSessionOptions extends Omit<SessionConfig, 'provider'> {
@@ -411,8 +412,20 @@ export async function getCodeState(dir: string): Promise<string> {
   }
 }
 
-export async function runLlmAudit(promptStr: string, codeStateSummary: string, apiKey?: string, abortSignal?: AbortSignal): Promise<AuditResult> {
-  const executionConfig = getAuditorExecutionConfig(apiKey);
+/**
+ * `executionConfigOverride` lets callers supply a pre-resolved
+ * ExecutionConfig (e.g. from the Issue 79 auditor rotation pool) instead of
+ * the single-tier default -- when omitted, behavior is unchanged from
+ * before the rotation pool existed.
+ */
+export async function runLlmAudit(
+  promptStr: string,
+  codeStateSummary: string,
+  apiKey?: string,
+  abortSignal?: AbortSignal,
+  executionConfigOverride?: ExecutionConfig,
+): Promise<AuditResult> {
+  const executionConfig = executionConfigOverride ?? getAuditorExecutionConfig(apiKey);
   const systemPrompt = `You are an expert security auditor and code reviewer operating as an isolated quality assurance suite. Analyze the provided codebase and audit it for vulnerabilities, validation gate status, and functional readiness relative to the requirements.
 You MUST submit structured verification feedback, logic checks, and compiler gate status using the 'submit_audit_findings' tool immediately. Do NOT reply with standard conversational text; you MUST call the 'submit_audit_findings' tool.`;
 

--- a/src/test/auditor_pool_rotation.test.ts
+++ b/src/test/auditor_pool_rotation.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import {
+  DEFAULT_ROLES_CONFIG,
+  parseAuditorPoolEnv,
+  selectFromAuditorPool,
+} from '../config/models';
+
+describe('Auditor model rotation pool (Issue 79 / RM-REQ-030/031/032/033)', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.AUDITOR_POOL;
+    delete process.env.AUDITOR_PROVIDER;
+    delete process.env.AUDITOR_MODEL;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  describe('parseAuditorPoolEnv', () => {
+    it('returns null when unset or blank', () => {
+      expect(parseAuditorPoolEnv(undefined)).toBeNull();
+      expect(parseAuditorPoolEnv('')).toBeNull();
+      expect(parseAuditorPoolEnv('   ')).toBeNull();
+    });
+
+    it('parses a single provider:model entry', () => {
+      expect(parseAuditorPoolEnv('gemini:gemini-3.1-flash-lite')).toEqual([
+        { provider: 'gemini', model: 'gemini-3.1-flash-lite' },
+      ]);
+    });
+
+    it('parses multiple comma-separated entries, trimming whitespace', () => {
+      expect(parseAuditorPoolEnv(' gemini:gemini-3.1-flash-lite , openai:gpt-4o-mini ')).toEqual([
+        { provider: 'gemini', model: 'gemini-3.1-flash-lite' },
+        { provider: 'openai', model: 'gpt-4o-mini' },
+      ]);
+    });
+
+    it('skips entries with an unknown provider', () => {
+      expect(parseAuditorPoolEnv('not-a-provider:some-model,gemini:gemini-3.5-flash')).toEqual([
+        { provider: 'gemini', model: 'gemini-3.5-flash' },
+      ]);
+    });
+
+    it('skips entries missing a colon separator', () => {
+      expect(parseAuditorPoolEnv('gemini-3.1-flash-lite,gemini:gemini-3.5-flash')).toEqual([
+        { provider: 'gemini', model: 'gemini-3.5-flash' },
+      ]);
+    });
+
+    it('skips entries with an empty model', () => {
+      expect(parseAuditorPoolEnv('gemini:,gemini:gemini-3.5-flash')).toEqual([
+        { provider: 'gemini', model: 'gemini-3.5-flash' },
+      ]);
+    });
+  });
+
+  describe('DEFAULT_ROLES_CONFIG.auditorPool', () => {
+    it('falls back to a single-entry pool (matching .auditor) when AUDITOR_POOL is unset', () => {
+      const pool = DEFAULT_ROLES_CONFIG.auditorPool;
+      expect(pool).toHaveLength(1);
+      expect(pool[0]).toEqual(DEFAULT_ROLES_CONFIG.auditor);
+    });
+
+    it('uses the parsed AUDITOR_POOL when set', () => {
+      process.env.AUDITOR_POOL = 'gemini:gemini-3.1-flash-lite,openai:gpt-4o-mini,anthropic:claude-3-5-sonnet';
+      const pool = DEFAULT_ROLES_CONFIG.auditorPool;
+      expect(pool).toEqual([
+        { provider: 'gemini', model: 'gemini-3.1-flash-lite' },
+        { provider: 'openai', model: 'gpt-4o-mini' },
+        { provider: 'anthropic', model: 'claude-3-5-sonnet' },
+      ]);
+    });
+
+    it('falls back to the single-entry default when AUDITOR_POOL parses to nothing usable', () => {
+      process.env.AUDITOR_POOL = 'garbage-with-no-colon';
+      const pool = DEFAULT_ROLES_CONFIG.auditorPool;
+      expect(pool).toHaveLength(1);
+      expect(pool[0]).toEqual(DEFAULT_ROLES_CONFIG.auditor);
+    });
+  });
+
+  describe('selectFromAuditorPool (deterministic round-robin)', () => {
+    beforeEach(() => {
+      process.env.AUDITOR_POOL = 'gemini:model-a,openai:model-b,anthropic:model-c';
+    });
+
+    it('selects entries in order as the rotation index increases', () => {
+      expect(selectFromAuditorPool(0)).toEqual({ provider: 'gemini', model: 'model-a' });
+      expect(selectFromAuditorPool(1)).toEqual({ provider: 'openai', model: 'model-b' });
+      expect(selectFromAuditorPool(2)).toEqual({ provider: 'anthropic', model: 'model-c' });
+    });
+
+    it('wraps around deterministically once the index exceeds the pool size', () => {
+      expect(selectFromAuditorPool(3)).toEqual(selectFromAuditorPool(0));
+      expect(selectFromAuditorPool(4)).toEqual(selectFromAuditorPool(1));
+      expect(selectFromAuditorPool(7)).toEqual(selectFromAuditorPool(1));
+    });
+
+    it('is a pure function: the same index always yields the same selection', () => {
+      const first = selectFromAuditorPool(5);
+      const second = selectFromAuditorPool(5);
+      expect(first).toEqual(second);
+    });
+
+    it('handles a negative index defensively by wrapping into bounds', () => {
+      // Defensive only -- callers should never pass negative indices in practice.
+      expect(selectFromAuditorPool(-1)).toEqual(selectFromAuditorPool(2));
+    });
+  });
+});
+
+describe('selectRotatingAuditorConfig (Issue 79 / RM-REQ-030/031/032)', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.AUDITOR_POOL;
+    process.env.GEMINI_API_KEY = 'test-gemini-key';
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('flags singleModelPool when only one model is configured (default pool)', async () => {
+    const { selectRotatingAuditorConfig } = await import('../utils/auditorHelper');
+    const selection = selectRotatingAuditorConfig(0);
+    expect(selection.singleModelPool).toBe(true);
+    expect(selection.poolSize).toBe(1);
+    expect(selection.nextRotationIndex).toBe(1);
+  });
+
+  it('does not flag singleModelPool when the pool has multiple models', async () => {
+    process.env.AUDITOR_POOL = 'gemini:gemini-3.1-flash-lite,gemini:gemini-3.5-flash';
+    vi.resetModules();
+    const { selectRotatingAuditorConfig } = await import('../utils/auditorHelper');
+    const first = selectRotatingAuditorConfig(0);
+    const second = selectRotatingAuditorConfig(1);
+
+    expect(first.singleModelPool).toBe(false);
+    expect(first.poolSize).toBe(2);
+    expect(first.executionConfig.model).toBe('gemini-3.1-flash-lite');
+    expect(second.executionConfig.model).toBe('gemini-3.5-flash');
+    expect(second.nextRotationIndex).toBe(2);
+  });
+
+  it('advances rotationIndex by exactly one per call regardless of pool size', async () => {
+    process.env.AUDITOR_POOL = 'gemini:gemini-3.1-flash-lite,gemini:gemini-3.5-flash,gemini:gemini-3.1-pro-preview';
+    vi.resetModules();
+    const { selectRotatingAuditorConfig } = await import('../utils/auditorHelper');
+    for (let i = 0; i < 5; i++) {
+      const selection = selectRotatingAuditorConfig(i);
+      expect(selection.nextRotationIndex).toBe(i + 1);
+    }
+  });
+});

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -23,6 +23,15 @@ export interface StateSnapshot {
   readonly failedGateFeedback?: string;
   readonly totalRetries?: number;
   readonly currentModelIndex?: number;
+  /**
+   * Issue 79 / RM-REQ-031: monotonically increasing counter used for
+   * deterministic round-robin selection from DEFAULT_ROLES_CONFIG.auditorPool.
+   * Persisted per session so rotation continues to advance across
+   * gate/verification attempts within the same task session, rather than
+   * resetting (which would defeat the point of rotating). Defaults to 0
+   * when absent (first audit attempt of a fresh session).
+   */
+  readonly auditorRotationIndex?: number;
 }
 
 export interface CopilotEventPayload {

--- a/src/utils/auditorHelper.ts
+++ b/src/utils/auditorHelper.ts
@@ -1,7 +1,7 @@
 import { runForcedToolTurn } from './toolCallEnforcement';
 import { CopilotClient, SdkProviderConfig, SessionConfig, CopilotSession, PermissionRequest, PermissionRequestResult } from '../copilotSdk/boundary';
 import { ProviderRegistry, ExecutionConfig } from './providerRegistry';
-import { DEFAULT_ROLES_CONFIG, getAuditorTierConfig } from '../config/models';
+import { DEFAULT_ROLES_CONFIG, getAuditorTierConfig, selectFromAuditorPool, ModelProviderConfig } from '../config/models';
 
 export interface ToolDefinition {
   readonly function: {
@@ -28,18 +28,15 @@ export interface ResponseRequirement {
 }
 
 /**
- * Shared logic to resolve the auditor's execution configuration via ProviderRegistry.
- * Ensures both auditors respect DEFAULT_ROLES_CONFIG.auditor.provider. * Throws a loud error if no API key is available for the required provider.
- *
- * `tierIndex` selects a rung on the auditor escalation ladder (Issue 81 /
- * RM-REQ-021), defaulting to tier 0 -- the same single-tier config this
- * function always resolved before the ladder existed, so existing callers
- * (e.g. the per-task Spec-Gate Auditor) are unaffected.
+ * Shared logic to resolve a role's ExecutionConfig via ProviderRegistry: pick
+ * up an explicit apiKey if given, otherwise fall back to the provider's env
+ * var. Throws a loud error if no API key is available for a provider that
+ * needs one. Shared by the auditor (single-tier/tiered/pooled), reviewer,
+ * and any future role -- keeps the provider/API-key resolution rules in one
+ * place instead of copy-pasted per role.
  */
-export function getAuditorExecutionConfig(apiKey?: string, tierIndex: number = 0): ExecutionConfig {
-  const auditorConfig = getAuditorTierConfig(tierIndex);
-  const provider = auditorConfig.provider;
-  // Resolve the key based on the provider
+function resolveExecutionConfig(roleConfig: ModelProviderConfig, roleLabel: string, apiKey?: string): ExecutionConfig {
+  const provider = roleConfig.provider;
   let keyToUse = apiKey;
   let envVarName = 'GEMINI_API_KEY';
   if (!keyToUse) {
@@ -60,11 +57,73 @@ export function getAuditorExecutionConfig(apiKey?: string, tierIndex: number = 0
 
   if (!keyToUse && provider !== 'copilot-native' && provider !== 'local') {
     throw new Error(
-      `Missing API key for auditor provider "${provider}". Expected ${envVarName} to be set.`,
+      `Missing API key for ${roleLabel} provider "${provider}". Expected ${envVarName} to be set.`,
     );
   }
   const registry = new ProviderRegistry(keyToUse);
-  return registry.getExecutionConfig(auditorConfig);
+  return registry.getExecutionConfig(roleConfig);
+}
+
+/**
+ * Shared logic to resolve the auditor's execution configuration via ProviderRegistry.
+ * Ensures both auditors respect DEFAULT_ROLES_CONFIG.auditor.provider. * Throws a loud error if no API key is available for the required provider.
+ *
+ * `tierIndex` selects a rung on the auditor escalation ladder (Issue 81 /
+ * RM-REQ-021), defaulting to tier 0 -- the same single-tier config this
+ * function always resolved before the ladder existed, so existing callers
+ * (e.g. the per-task Spec-Gate Auditor) are unaffected.
+ *
+ * This is intentionally independent of the pool-rotation mechanism below
+ * (Issue 79 / RM-REQ-033): the compliance-audit operation's tiering must
+ * not be conflated with the general auditor's rotation pool.
+ */
+export function getAuditorExecutionConfig(apiKey?: string, tierIndex: number = 0): ExecutionConfig {
+  const auditorConfig = getAuditorTierConfig(tierIndex);
+  return resolveExecutionConfig(auditorConfig, 'auditor', apiKey);
+}
+
+export interface RotatingAuditorSelection {
+  readonly executionConfig: ExecutionConfig;
+  /** Number of models currently configured in the pool. */
+  readonly poolSize: number;
+  /** The pool index actually selected for this call (rotationIndex normalized into pool bounds). */
+  readonly selectedIndex: number;
+  /** Value to persist as the rotation index for the *next* call (RM-REQ-031: session-persisted, deterministic). */
+  readonly nextRotationIndex: number;
+  /** True when the configured pool has only one model (RM-REQ-032: warn, don't block). */
+  readonly singleModelPool: boolean;
+}
+
+/**
+ * Round-robin auditor selection from DEFAULT_ROLES_CONFIG.auditorPool
+ * (Issue 79 / RM-REQ-030/031). Pure with respect to session state: callers
+ * are responsible for reading the current rotationIndex out of session
+ * state before calling this, and persisting `nextRotationIndex` back after
+ * (see StateSnapshot.auditorRotationIndex) -- this function does not read
+ * or write any session store itself, so it stays trivially testable and
+ * avoids a dependency on the session-state module (which itself depends on
+ * this one).
+ *
+ * Warnings (single-model pool, decorrelation) are reported back via the
+ * returned flags rather than logged here directly, so callers can route
+ * them through whatever logger/session-event mechanism they already use.
+ */
+export function selectRotatingAuditorConfig(rotationIndex: number, apiKey?: string): RotatingAuditorSelection {
+  const pool = DEFAULT_ROLES_CONFIG.auditorPool;
+  if (pool.length === 0) {
+    throw new Error('Auditor pool is empty');
+  }
+  const normalizedIndex = ((rotationIndex % pool.length) + pool.length) % pool.length;
+  const auditorConfig = selectFromAuditorPool(rotationIndex);
+  const executionConfig = resolveExecutionConfig(auditorConfig, 'auditor pool', apiKey);
+
+  return {
+    executionConfig,
+    poolSize: pool.length,
+    selectedIndex: normalizedIndex,
+    nextRotationIndex: rotationIndex + 1,
+    singleModelPool: pool.length <= 1,
+  };
 }
 
 /**
@@ -75,33 +134,7 @@ export function getAuditorExecutionConfig(apiKey?: string, tierIndex: number = 0
  * Throws a loud error if no API key is available for the required provider.
  */
 export function getReviewerExecutionConfig(apiKey?: string): ExecutionConfig {
-  const reviewerConfig = DEFAULT_ROLES_CONFIG.reviewer;
-  const provider = reviewerConfig.provider;
-  let keyToUse = apiKey;
-  let envVarName = 'GEMINI_API_KEY';
-  if (!keyToUse) {
-    if (provider === 'gemini') {
-      keyToUse = process.env.GEMINI_API_KEY;
-      envVarName = 'GEMINI_API_KEY';
-    } else if (provider === 'anthropic') {
-      keyToUse = process.env.ANTHROPIC_API_KEY;
-      envVarName = 'ANTHROPIC_API_KEY';
-    } else if (provider === 'openai') {
-      keyToUse = process.env.OPENAI_API_KEY;
-      envVarName = 'OPENAI_API_KEY';
-    } else if (provider === 'openrouter') {
-      keyToUse = process.env.OPENROUTER_API_KEY;
-      envVarName = 'OPENROUTER_API_KEY';
-    }
-  }
-
-  if (!keyToUse && provider !== 'copilot-native' && provider !== 'local') {
-    throw new Error(
-      `Missing API key for reviewer provider "${provider}". Expected ${envVarName} to be set.`,
-    );
-  }
-  const registry = new ProviderRegistry(keyToUse);
-  return registry.getExecutionConfig(reviewerConfig);
+  return resolveExecutionConfig(DEFAULT_ROLES_CONFIG.reviewer, 'reviewer', apiKey);
 }
 
 /**


### PR DESCRIPTION
Implements RM-REQ-030/031/032/033.

- config/models.ts: SystemRolesConfig gains `auditorPool`, a list of ModelProviderConfig parsed from a new AUDITOR_POOL env var (comma-separated `provider:model` entries, e.g. `gemini:gemini-3.1-flash-lite,openai:gpt-4o-mini`). Falls back to a single-entry pool (matching the existing `auditor` config) when unset, so the "single-model pool" warning surfaces by default until an operator opts into a real pool. Added `parseAuditorPoolEnv()` (skips malformed entries with a console warning rather than throwing) and `selectFromAuditorPool(rotationIndex)` (pure, deterministic round-robin with defensive negative-index wraparound).

- utils/auditorHelper.ts: extracted the duplicated provider/API-key resolution logic (previously copy-pasted between getAuditorExecutionConfig and getReviewerExecutionConfig) into a shared resolveExecutionConfig() helper. Added selectRotatingAuditorConfig(rotationIndex, apiKey), a pure function returning the selected ExecutionConfig plus poolSize, nextRotationIndex, and a singleModelPool flag. Deliberately independent of getAuditorExecutionConfig's tierIndex path (used by compliance-audit, Issue 81/RM-REQ-021) -- RM-REQ-033 requires the two mechanisms not be conflated, and this keeps them as separate code paths that happen to share only the provider/key-resolution plumbing.

- types/session.ts: StateSnapshot gains `auditorRotationIndex?: number` so the round-robin counter is session-persisted and keeps advancing across gate/verification attempts within a task (RM-REQ-031).

- orchestrator/gateLoop.ts: new selectAndAdvanceAuditorRotation() helper reads the session's current rotation index, selects the next pool model, logs the two required non-blocking warnings (single-model pool; selected auditor matches the Implementor's model for that task -- reduced decorrelation), and persists the advanced index via updateStateSnapshot. Wired into both the `runAudit` and `runSpecAudit` gate call sites (both are per-gate/verification-attempt calls within the retry loop).

- orchestrator/sessionState.ts (runLlmAudit) and gates/specAuditor.ts (runSpecAudit): both gained an optional executionConfigOverride param so gateLoop can inject the rotated selection. Omitting it keeps prior behavior unchanged for any other caller.

16 new tests in src/test/auditor_pool_rotation.test.ts covering: parseAuditorPoolEnv (unset/blank, single/multiple entries, malformed provider/missing-colon/empty-model skipping), the default single-entry-pool fallback, AUDITOR_POOL-driven pool construction, selectFromAuditorPool's deterministic round-robin/wraparound/purity, and selectRotatingAuditorConfig's singleModelPool flag and per-call rotation advancement.

Verified: tsc --noEmit clean, full suite 53 files / 224 tests passing.



---


## Overview
Implement a configurable rotation pool for auditor models. Replace the single `provider`/`model` pair with a list, rotating through models on each gate/verification attempt via deterministic round-robin.

## Requirements
- RM-REQ-030, RM-REQ-031, RM-REQ-032, RM-REQ-033

## Acceptance Criteria
- [ ] `DEFAULT_ROLES_CONFIG.auditor` becomes/gains an `AUDITOR_POOL` list in `src/config/models.ts`
- [ ] `getAuditorExecutionConfig()` in `src/utils/auditorHelper.ts` updated for round-robin rotation
- [ ] Rotation index persisted in session state, deterministic selection implemented
- [ ] Warning logged (not blocking) on:
  - Single-model pool
  - Selected auditor matches the Implementor's model for that task (reduced decorrelation)
- [ ] Compliance-audit model selection (Issue 9) left independent of this pool
  - The tiering rule in Issue 9 should select its model independently

## Details
This is a genuine config-schema change plus a rotation index threaded through session state — not just new selection logic layered on top. The compliance audit uses a separate tiering mechanism and must not be conflated with this rotation pool.

## Dependencies
None — this is ready to implement independently.