### PR TITLE
Fix flaky process-cleanup test: replace timing assumptions with sync/…

### DIFF
--- a/src/test/process_cleanup.test.ts
+++ b/src/test/process_cleanup.test.ts
@@ -3,6 +3,31 @@ import { runNativeProcess } from "../workspace/nativeRunner.js";
 import { execSync } from "child_process";
 import * as os from "os";
 
+/**
+ * Polls `check()` at `intervalMs` until it returns true or `timeoutMs`
+ * elapses, then returns the last observed value. Used instead of a fixed
+ * `setTimeout` wait so the test proceeds as soon as the real condition it
+ * cares about is true, rather than assuming a fixed duration is enough --
+ * the polling interval is just a cadence, not a correctness assumption.
+ */
+async function pollUntil(check: () => boolean, timeoutMs: number, intervalMs = 20): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  let last = check();
+  while (!last && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, intervalMs));
+    last = check();
+  }
+  return last;
+}
+
+function isSleep100Running(): boolean {
+  try {
+    return execSync("ps aux | grep '[s]leep 100' || true").toString().includes("sleep 100");
+  } catch (e) {
+    return false;
+  }
+}
+
 describe("Process Cleanup & Orphan Handling", () => {
   afterEach(() => {
     // Cleanup any lingering sleep processes we spawn in these tests
@@ -22,25 +47,27 @@ describe("Process Cleanup & Orphan Handling", () => {
 
     const ac = new AbortController();
     
-    // We launch a bash command that backgrounds a long sleep.
-    // Without process group killing, the `sleep` would outlive the aborted bash parent.
+    // We launch a bash command that backgrounds a long sleep and then waits
+    // on it. Without process group killing, the `sleep` (and the `wait`ing
+    // bash parent) would outlive the aborted parent.
+    //
+    // Deliberately `wait`s on the background job rather than doing a short
+    // `sleep 0.5` and exiting: under load (e.g. the full test suite running
+    // many processes in parallel), a short-lived parent can race ahead and
+    // exit normally (exitCode 0) before the abort signal is even dispatched,
+    // making this test flaky. Waiting on the 100s background job means the
+    // parent is still alive (and killable) for the full duration of the
+    // test regardless of scheduling delays.
     const p = runNativeProcess(`
       sleep 100 &
-      # Give bash some time to start the sleep
-      sleep 0.5
+      wait
     `, ac.signal);
     
-    // Wait for the bash shell and its background sleep child to spin up
-    await new Promise(r => setTimeout(r, 200));
-    
-    // Check that the process exists
-    let psOutBefore = "";
-    try {
-      psOutBefore = execSync("ps aux | grep '[s]leep 100' || true").toString();
-    } catch (e) {
-      // Ignore
-    }
-    assert.ok(psOutBefore.includes("sleep 100"), "Background sleep process should be running before abort");
+    // Wait for the bash shell and its background sleep child to actually
+    // spin up and become visible to `ps`, polling instead of assuming a
+    // fixed duration is always enough (e.g. under a loaded CI host).
+    const spawnedInTime = await pollUntil(isSleep100Running, 5000);
+    assert.ok(spawnedInTime, "Background sleep process should be running before abort");
 
     // Abort the process, which should kill the process group
     ac.abort();
@@ -49,16 +76,11 @@ describe("Process Cleanup & Orphan Handling", () => {
     // When killed via signal, exitCode is usually null
     assert.ok(result.exitCode === null || result.exitCode === 1, "Expected exit code null (SIGKILL) or 1");
 
-    // Give the OS a tiny moment to reap the killed processes
-    await new Promise(r => setTimeout(r, 100));
-
-    // Verify the descendant `sleep 100` process is gone
-    let psOutAfter = "";
-    try {
-      psOutAfter = execSync("ps aux | grep '[s]leep 100' || true").toString();
-    } catch(e) {
-      // Ignore
-    }
-    assert.strictEqual(psOutAfter.includes("sleep 100"), false, "Descendant process should have been terminated");
+    // Verify the descendant `sleep 100` process is actually gone, polling
+    // for its disappearance rather than assuming the OS has reaped it after
+    // a fixed delay -- SIGKILL is sent immediately but the kernel reaping
+    // the process can lag arbitrarily under load.
+    const reapedInTime = await pollUntil(() => !isSleep100Running(), 5000);
+    assert.ok(reapedInTime, "Descendant process should have been terminated");
   });
 });


### PR DESCRIPTION
…polling

The "process group kill on abort" test had two independent timing assumptions, either of which could make it flaky under load (e.g. running the full suite, where many processes contend for CPU):

1. It spawned `sleep 100 & ; sleep 0.5` and called abort() after a fixed 200ms setTimeout. Under load, the parent's own `sleep 0.5` could occasionally finish -- and the parent exit normally with exitCode 0 -- before the 200ms timer fired. That produced the reported flake: `Expected exit code null (SIGKILL) or 1: expected false to be truthy` (exitCode was 0, because nothing was actually killed -- the parent had already exited on its own).

2. It waited a fixed 200ms before checking `ps aux` for the spawned process, and a fixed 100ms after SIGKILL before checking it was gone -- both just hoping a fixed duration was enough.

Fixed both without leaning on any tuned wait time:

- The parent now does `sleep 100 & ; wait` instead of a short sleep-and-exit. `wait` is a bash builtin that blocks until the background job actually exits (or is signaled) -- not a timer, an actual synchronization primitive. This removes race #1 entirely: the parent is guaranteed alive until killed, regardless of scheduling delays.
- Both fixed-duration waits (for the process to appear, and for it to be reaped after SIGKILL) are replaced with condition-polling (`pollUntil`): check the real condition (`ps aux` output) every 20ms up to a 5s ceiling, proceeding as soon as it's actually true rather than assuming a fixed duration is enough. The ceiling only fails the test if the condition genuinely never becomes true -- it's not the source of correctness, the condition check is.

Verified: tsc --noEmit clean; ran the test 5x standalone and 5x under synthetic CPU load (three concurrent `yes > /dev/null` processes) with no flakes in either case -- and notably faster (test now finishes in ~40-170ms instead of always paying the old fixed ~300-450ms, since it no longer waits longer than necessary). Full suite (52 files / 208 tests) passes clean.