### PR TITLE
Stall-retry: create a fresh session instead of resuming

### DIFF
--- a/src/test/toolCallEnforcement.test.ts
+++ b/src/test/toolCallEnforcement.test.ts
@@ -188,5 +188,141 @@ describe('Upstream stall detection & retry (review-pr.ts stall-retry follow-up)'
       await assertion;
       expect(mockClient.resumeSession).toHaveBeenCalledTimes(1);
     });
+
+    it('creates a brand-new session (not resumeSession) on stall when freshSessionConfig is provided', async () => {
+      let sessionCount = 0;
+      const makeSession = (resolves: boolean) => {
+        sessionCount++;
+        return {
+          sessionId: `session-${sessionCount}`,
+          on: vi.fn().mockReturnValue(vi.fn()),
+          sendAndWait: vi.fn().mockImplementation(() => (resolves ? Promise.resolve() : new Promise(() => {}))),
+        };
+      };
+
+      const initialSession = makeSession(false); // stalls
+      const freshSessionConfig = { workingDirectory: '/tmp', systemPrompt: 'x', tools: [] } as any;
+      const mockClient = {
+        createSession: vi.fn().mockImplementation(async () => makeSession(true)), // succeeds
+        resumeSession: vi.fn(),
+      } as any;
+      const onSessionId = vi.fn();
+
+      const runPromise = runForcedToolTurn(initialSession as any, {}, 'my_tool', 'test prompt', {
+        client: mockClient,
+        maxRetries: 0,
+        maxStallRetries: 1,
+        getResult: () => ({ ok: true }),
+        tools: [],
+        freshSessionConfig,
+        onSessionId,
+      });
+
+      // The turn will still ultimately fail (no tool-call event ever fires
+      // in this mock), but what we care about here is *how* the stall was
+      // recovered from, not the final outcome.
+      const assertion = expect(runPromise).rejects.toThrow(/Session ended without calling 'my_tool'/);
+      await vi.advanceTimersByTimeAsync(STALL_TIMEOUT_MS + 5000);
+      await assertion;
+
+      expect(mockClient.createSession).toHaveBeenCalledTimes(1);
+      expect(mockClient.createSession).toHaveBeenCalledWith(freshSessionConfig);
+      expect(mockClient.resumeSession).not.toHaveBeenCalled();
+
+      // onSessionId must fire again with the new session's id, so callers
+      // that correlate outbound requests via a global (e.g.
+      // scripts/review-pr.ts's setActiveOpenRouterSessionId) stay in sync.
+      expect(onSessionId).toHaveBeenCalledWith('session-2');
+    });
+
+    it('falls back to resumeSession when no freshSessionConfig is supplied', async () => {
+      let sessionCount = 0;
+      const makeSession = (resolves: boolean) => {
+        sessionCount++;
+        return {
+          sessionId: `session-${sessionCount}`,
+          on: vi.fn().mockReturnValue(vi.fn()),
+          sendAndWait: vi.fn().mockImplementation(() => (resolves ? Promise.resolve() : new Promise(() => {}))),
+        };
+      };
+
+      const initialSession = makeSession(false);
+      const mockClient = {
+        createSession: vi.fn(),
+        resumeSession: vi.fn().mockImplementation(async () => makeSession(true)),
+      } as any;
+
+      const runPromise = runForcedToolTurn(initialSession as any, {}, 'my_tool', 'test prompt', {
+        client: mockClient,
+        maxRetries: 0,
+        maxStallRetries: 1,
+        getResult: () => ({ ok: true }),
+        tools: [],
+        // no freshSessionConfig
+      });
+
+      const assertion = expect(runPromise).rejects.toThrow(/Session ended without calling 'my_tool'/);
+      await vi.advanceTimersByTimeAsync(STALL_TIMEOUT_MS + 5000);
+      await assertion;
+
+      expect(mockClient.resumeSession).toHaveBeenCalledTimes(1);
+      expect(mockClient.createSession).not.toHaveBeenCalled();
+    });
+
+    it('restarts from the original prompt (not the in-flight nudge) when a stall happens mid-nudge-retry', async () => {
+      let sessionCount = 0;
+      const sentPrompts: string[] = [];
+      const makeSession = (behavior: 'stall' | 'resolve') => {
+        sessionCount++;
+        const id = `session-${sessionCount}`;
+        return {
+          sessionId: id,
+          on: vi.fn().mockReturnValue(vi.fn()),
+          sendAndWait: vi.fn().mockImplementation((opts: { prompt: string }) => {
+            sentPrompts.push(opts.prompt);
+            return behavior === 'stall' ? new Promise(() => {}) : Promise.resolve();
+          }),
+        };
+      };
+
+      // Turn 1 (initial prompt): resolves normally but never calls the tool
+      // -> triggers the nudge-retry path.
+      const initialSession = makeSession('resolve');
+      const freshSessionConfig = { workingDirectory: '/tmp', systemPrompt: 'x', tools: [] } as any;
+
+      let resumeCallCount = 0;
+      const mockClient = {
+        createSession: vi.fn().mockImplementation(async () => makeSession('resolve')),
+        resumeSession: vi.fn().mockImplementation(async () => {
+          resumeCallCount++;
+          // The nudge-retry's own resumeSession() call returns a session
+          // whose *next* send (the nudge itself) stalls.
+          return makeSession('stall');
+        }),
+      } as any;
+
+      const runPromise = runForcedToolTurn(initialSession as any, {}, 'my_tool', 'test prompt', {
+        client: mockClient,
+        maxRetries: 1,
+        maxStallRetries: 1,
+        getResult: () => ({ ok: true }),
+        tools: [],
+        freshSessionConfig,
+      });
+
+      const assertion = expect(runPromise).rejects.toThrow(/Session ended without calling 'my_tool'/);
+      await vi.advanceTimersByTimeAsync(STALL_TIMEOUT_MS + 5000);
+      await assertion;
+
+      expect(sentPrompts[0]).toBe('test prompt'); // initial turn
+      // The nudge-retry's resumeSession call happened once (the ordinary,
+      // non-stall nudge resume), and its send (the nudge itself) is what stalls...
+      expect(resumeCallCount).toBe(1);
+      expect(sentPrompts[1]).toContain('ended your turn without calling');
+      // ...so recovery used createSession (not yet another resumeSession)
+      // and resent the *original* prompt, not another nudge.
+      expect(sentPrompts[2]).toBe('test prompt');
+      expect(mockClient.createSession).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/utils/auditorHelper.ts
+++ b/src/utils/auditorHelper.ts
@@ -276,7 +276,12 @@ export async function executeAuditSession<T>(
       maxRetries,
       getResult: () => result,
       tools: sessionSettings.tools,
-      responseRequirements
+      responseRequirements,
+      freshSessionConfig: sessionSettings as SessionConfig & { autoApproveAll?: boolean },
+      onSessionId: (id) => {
+        sessionId = id;
+        onSessionId?.(id);
+      },
     });
     
     result = turnResult.result;

--- a/src/utils/toolCallEnforcement.ts
+++ b/src/utils/toolCallEnforcement.ts
@@ -135,7 +135,31 @@ export interface ForcedToolTurnOptions<T> {
    * gateLoop.ts's per-model stall-retry allowance.
    */
   maxStallRetries?: number;
+  /**
+   * When provided, a stall recovery creates a brand-new session via
+   * `client.createSession(freshSessionConfig)` instead of resuming the
+   * stalled one. Resuming a session that never got a response from the
+   * upstream provider re-sends into the same (likely still-wedged)
+   * conversation; starting fresh avoids that. Because a fresh session has
+   * no conversation history, recovery always restarts from `initialPrompt`
+   * rather than replaying whatever prompt was in flight (e.g. a nudge),
+   * since the fresh session wouldn't have the context a nudge presupposes.
+   * If omitted, falls back to the previous `client.resumeSession()`
+   * behavior (which does replay the exact in-flight prompt, since resuming
+   * preserves conversation history).
+   */
+  freshSessionConfig?: SessionConfig & { autoApproveAll?: boolean };
+  /**
+   * Called with the id of every session this turn runs on, including ones
+   * created mid-turn by stall recovery (`createSession` or `resumeSession`).
+   * Callers that correlate outbound requests via a session id stored
+   * globally (e.g. scripts/review-pr.ts's setActiveOpenRouterSessionId)
+   * need this to stay in sync across retries -- `onSession` above is for
+   * attaching per-session listeners, this is for tracking the id itself.
+   */
+  onSessionId?: (sessionId: string) => void;
 }
+
 
 export async function runForcedToolTurn<T>(
   session: CopilotSession,
@@ -187,24 +211,37 @@ export async function runForcedToolTurn<T>(
     resumeConfig: { availableTools?: string[]; tools?: unknown; provider?: ProviderConfig },
   ): Promise<void> => {
     let stallAttempt = 0;
+    let currentPromptOpts = promptOpts;
     while (true) {
       try {
-        await sendAndWaitWithAbort(currentSession, promptOpts as MessageOptions, timeoutMs, opts.abortSignal);
+        await sendAndWaitWithAbort(currentSession, currentPromptOpts as MessageOptions, timeoutMs, opts.abortSignal);
         return;
       } catch (err) {
         if (!isStallError(err) || stallAttempt >= maxStallRetries) {
           throw err;
         }
         stallAttempt++;
-        console.warn(
-          `[runForcedToolTurn] upstream stall detected (attempt ${stallAttempt}/${maxStallRetries}); ` +
-          `resuming session and retrying the same prompt...`,
-        );
         unsubOnSession?.();
         tracker.unsubscribe();
         unsubTool();
-        currentSession = await opts.client.resumeSession(currentSessionId, resumeConfig as SessionConfig);
-        currentSessionId = currentSession.sessionId;
+        if (opts.freshSessionConfig) {
+          console.warn(
+            `[runForcedToolTurn] upstream stall detected (attempt ${stallAttempt}/${maxStallRetries}); ` +
+            `starting a new session and retrying the original prompt...`,
+          );
+          currentSession = await opts.client.createSession(opts.freshSessionConfig);
+          currentSessionId = currentSession.sessionId;
+          opts.onSessionId?.(currentSessionId);
+          currentPromptOpts = { prompt: initialPrompt };
+        } else {
+          console.warn(
+            `[runForcedToolTurn] upstream stall detected (attempt ${stallAttempt}/${maxStallRetries}); ` +
+            `resuming session and retrying the same prompt...`,
+          );
+          currentSession = await opts.client.resumeSession(currentSessionId, resumeConfig as SessionConfig);
+          currentSessionId = currentSession.sessionId;
+          opts.onSessionId?.(currentSessionId);
+        }
         tracker = trackLastAssistantMessage(currentSession);
         toolCalled = false;
         unsubTool = setupToolListener(currentSession);
@@ -244,6 +281,7 @@ export async function runForcedToolTurn<T>(
     
     currentSession = await opts.client.resumeSession(currentSessionId, resumeConfig);
     currentSessionId = currentSession.sessionId;
+    opts.onSessionId?.(currentSessionId);
     
     unsubOnSession?.();
     tracker = trackLastAssistantMessage(currentSession);


### PR DESCRIPTION
Resuming a session that stalled means re-sending into the same conversation that never got a response from the upstream provider, which risks retrying into a still-wedged connection. When freshSessionConfig is supplied, sendWithStallRetry now calls client.createSession() instead of client.resumeSession() on stall, and restarts from the original prompt rather than replaying whatever was in flight (e.g. a nudge), since a fresh session has no conversation history for a nudge to refer back to.

Non-stall failures (turn ended without calling the tool) are unaffected and still resume the same session, as before.

Adds onSessionId to ForcedToolTurnOptions so callers that track the active session id in a global (e.g. review-pr.ts) stay in sync across every session created mid-turn, stall-triggered or not. Falls back to the previous resumeSession-based behavior when freshSessionConfig is omitted.

executeAuditSession now passes its own sessionSettings as freshSessionConfig and wires onSessionId through.