### PR TITLE
fix(session): resume instead of recreate session on stall/context mis…

### DIFF
--- a/src/orchestrator/sessionState.ts
+++ b/src/orchestrator/sessionState.ts
@@ -165,7 +165,7 @@ export async function getOrCreateSession(
 
   if (existing) {
     if (existing.currentModel !== currentModel || existing.cwd !== cwd || !existing.copilotSession) {
-      writeLog(`[Session] Context mismatch or missing copilotSession detected for ${sessionId}. Recreating session context.`);
+      writeLog(`[Session] Context mismatch or missing copilotSession detected for ${sessionId}. Resuming session context.`);
       try {
         existing.unsubscribe?.();
         if (existing.copilotSession) {
@@ -174,7 +174,22 @@ export async function getOrCreateSession(
       } catch (err) {
         writeLog(`[Session] Error disconnecting outdated session ${sessionId}: ${err}`);
       }
-      const newSession = await client.createSession(createSessionOptions);
+      // `existing` means sessionId maps to a previously known session (either
+      // still in memory or rehydrated from the DB), so reconnect to it via
+      // resumeSession rather than starting a brand-new one -- this is what
+      // was actually causing loss of conversation/prompt continuity on
+      // stalls (see #154), which were misdiagnosed as provider-side hangs
+      // rather than the ~10-minute server-side idle timeout they really are.
+      // Only fall back to createSession if resuming genuinely fails (e.g.
+      // the underlying SDK session is truly unrecoverable) -- fail loud via
+      // logging rather than silently masking a real dead-session case.
+      let newSession: CopilotSession;
+      try {
+        newSession = await client.resumeSession(sessionId, createSessionOptions);
+      } catch (err) {
+        writeLog(`[Session] resumeSession(${sessionId}) failed, falling back to createSession: ${err}`, LogLevel.WARN);
+        newSession = await client.createSession(createSessionOptions);
+      }
       const updated: SessionRecord = {
         sessionId,
         copilotSession: newSession,


### PR DESCRIPTION
…match (#154)

getOrCreateSession's 'context mismatch or missing copilotSession' branch previously called client.createSession() whenever a mapped session's copilotSession was missing/stale -- including the path hit after an UpstreamStreamStall retry. This was based on a wrong assumption that stalls were provider-side hangs; they're actually caused by a ~10-minute server-side idle timeout, so starting a brand-new session needlessly threw away conversation/prompt continuity.

Swap client.createSession() for client.resumeSession(sessionId, ...) in that branch, mirroring the resumeSession-based pattern already used by runForcedToolTurn for forced-tool-use retries. Falls back to createSession (with a WARN log) only if resuming genuinely fails, so a truly unrecoverable session still fails loud instead of silently masking a dead-session case.

gateLoop.ts's UpstreamStreamStall retry path already flows back through getOrCreateSession at the top of the while-loop body on 'continue', so no changes were needed there -- confirmed it does not go through the separate 'Creating fresh session' branch (which only fires when there is no sessionId at all).