### PR TITLE
fix(session): resume instead of recreate session on stall/context mis…

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -89,6 +89,9 @@ const sessionsColumns = db.pragma('table_info(sessions)') as { name: string }[];
 if (!sessionsColumns.some(col => col.name === 'taskId')) {
   db.prepare('ALTER TABLE sessions ADD COLUMN taskId TEXT').run();
 }
+if (!sessionsColumns.some(col => col.name === 'copilotSessionId')) {
+  db.prepare('ALTER TABLE sessions ADD COLUMN copilotSessionId TEXT').run();
+}
 
 const tasksColumns = db.pragma('table_info(tasks)') as { name: string }[];
 if (!tasksColumns.some(col => col.name === 'pbiId')) {

--- a/src/db/sessionStore.ts
+++ b/src/db/sessionStore.ts
@@ -7,6 +7,7 @@ interface SessionRow {
   readonly taskId?: string;
   readonly currentModel: string;
   readonly cwd: string;
+  readonly copilotSessionId?: string;
   readonly lastUsedAt: number;
   readonly currentTierIndex: number;
   readonly planVersions?: string;
@@ -27,6 +28,7 @@ export function getSession(sessionId: string): Partial<SessionRecord> | undefine
     taskId: row.taskId,
     currentModel: row.currentModel as ModelTier, // TODO: refine Model type
     cwd: row.cwd,
+    copilotSessionId: row.copilotSessionId || undefined,
     lastUsedAt: row.lastUsedAt,
     currentTierIndex: row.currentTierIndex,
     planVersions: row.planVersions ? JSON.parse(row.planVersions) : undefined,
@@ -43,12 +45,12 @@ export function getSession(sessionId: string): Partial<SessionRecord> | undefine
 export function saveSession(session: SessionRecord) {
   const stmt = db.prepare(`
     INSERT INTO sessions (
-      sessionId, taskId, currentModel, cwd, lastUsedAt, currentTierIndex,
+      sessionId, taskId, currentModel, cwd, copilotSessionId, lastUsedAt, currentTierIndex,
       planVersions, totalInputTokens, totalOutputTokens,
       eventSequenceCounter, stateSnapshot, conversationHistory,
       turns, diagnosticTrail
     ) VALUES (
-      @sessionId, @taskId, @currentModel, @cwd, @lastUsedAt, @currentTierIndex,
+      @sessionId, @taskId, @currentModel, @cwd, @copilotSessionId, @lastUsedAt, @currentTierIndex,
       @planVersions, @totalInputTokens, @totalOutputTokens,
       @eventSequenceCounter, @stateSnapshot, @conversationHistory,
       @turns, @diagnosticTrail
@@ -57,6 +59,7 @@ export function saveSession(session: SessionRecord) {
       taskId = excluded.taskId,
       currentModel = excluded.currentModel,
       cwd = excluded.cwd,
+      copilotSessionId = excluded.copilotSessionId,
       lastUsedAt = excluded.lastUsedAt,
       currentTierIndex = excluded.currentTierIndex,
       planVersions = excluded.planVersions,
@@ -74,6 +77,7 @@ export function saveSession(session: SessionRecord) {
     taskId: session.taskId || null,
     currentModel: session.currentModel,
     cwd: session.cwd,
+    copilotSessionId: session.copilotSessionId || null,
     lastUsedAt: session.lastUsedAt,
     currentTierIndex: session.currentTierIndex,
     planVersions: session.planVersions ? JSON.stringify(session.planVersions) : null,
@@ -94,6 +98,7 @@ export function getAllSessions(): ReadonlyArray<Partial<SessionRecord>> {
     taskId: row.taskId,
     currentModel: row.currentModel as ModelTier,
     cwd: row.cwd,
+    copilotSessionId: row.copilotSessionId || undefined,
     lastUsedAt: row.lastUsedAt,
     currentTierIndex: row.currentTierIndex,
     planVersions: row.planVersions ? JSON.parse(row.planVersions) : undefined,

--- a/src/orchestrator/sessionState.ts
+++ b/src/orchestrator/sessionState.ts
@@ -165,7 +165,7 @@ export async function getOrCreateSession(
 
   if (existing) {
     if (existing.currentModel !== currentModel || existing.cwd !== cwd || !existing.copilotSession) {
-      writeLog(`[Session] Context mismatch or missing copilotSession detected for ${sessionId}. Recreating session context.`);
+      writeLog(`[Session] Context mismatch or missing copilotSession detected for ${sessionId}. Resuming session context.`);
       try {
         existing.unsubscribe?.();
         if (existing.copilotSession) {
@@ -174,7 +174,22 @@ export async function getOrCreateSession(
       } catch (err) {
         writeLog(`[Session] Error disconnecting outdated session ${sessionId}: ${err}`);
       }
-      const newSession = await client.createSession(createSessionOptions);
+      // `existing` means sessionId maps to a previously known session (either
+      // still in memory or rehydrated from the DB), so reconnect to it via
+      // resumeSession rather than starting a brand-new one -- this is what
+      // was actually causing loss of conversation/prompt continuity on
+      // stalls (see #154), which were misdiagnosed as provider-side hangs
+      // rather than the ~10-minute server-side idle timeout they really are.
+      // Only fall back to createSession if resuming genuinely fails (e.g.
+      // the underlying SDK session is truly unrecoverable) -- fail loud via
+      // logging rather than silently masking a real dead-session case.
+      let newSession: CopilotSession;
+      try {
+        newSession = await client.resumeSession(sessionId, createSessionOptions);
+      } catch (err) {
+        writeLog(`[Session] resumeSession(${sessionId}) failed, falling back to createSession: ${err}`, LogLevel.WARN);
+        newSession = await client.createSession(createSessionOptions);
+      }
       const updated: SessionRecord = {
         sessionId,
         copilotSession: newSession,

--- a/src/orchestrator/sessionState.ts
+++ b/src/orchestrator/sessionState.ts
@@ -164,8 +164,15 @@ export async function getOrCreateSession(
   const safeModelTier = (MODEL_TIERS.includes(currentModel) ? currentModel : MODEL_TIERS[0]) || 'gemini-3.1-flash-lite';
 
   if (existing) {
-    if (existing.currentModel !== currentModel || existing.cwd !== cwd || !existing.copilotSession) {
-      writeLog(`[Session] Context mismatch or missing copilotSession detected for ${sessionId}. Resuming session context.`);
+    const modelOrCwdChanged = existing.currentModel !== currentModel || existing.cwd !== cwd;
+    if (modelOrCwdChanged || !existing.copilotSession) {
+      writeLog(`[Session] Context mismatch or missing copilotSession detected for ${sessionId}. ${modelOrCwdChanged ? 'Recreating' : 'Resuming'} session context.`);
+      // The real server-side Copilot session ID (a random UUID the SDK
+      // assigns) is only reachable via a *live* CopilotSession object's
+      // .sessionId -- it is never persisted to the DB and is NOT the same
+      // as `sessionId`, which is only the client-side activeSessions Map
+      // key. Capture it before disconnecting below.
+      const realSessionId = existing.copilotSession?.sessionId;
       try {
         existing.unsubscribe?.();
         if (existing.copilotSession) {
@@ -174,20 +181,40 @@ export async function getOrCreateSession(
       } catch (err) {
         writeLog(`[Session] Error disconnecting outdated session ${sessionId}: ${err}`);
       }
-      // `existing` means sessionId maps to a previously known session (either
-      // still in memory or rehydrated from the DB), so reconnect to it via
-      // resumeSession rather than starting a brand-new one -- this is what
-      // was actually causing loss of conversation/prompt continuity on
-      // stalls (see #154), which were misdiagnosed as provider-side hangs
-      // rather than the ~10-minute server-side idle timeout they really are.
+      // Only resume when the model/cwd are unchanged and we merely lost the
+      // live session object (e.g. after an UpstreamStreamStall retry, or a
+      // session rehydrated mid-flight) -- that's the actual stall/reconnect
+      // scenario this fixes (see #154): it was misdiagnosed as a
+      // provider-side hang and "fixed" by discarding the live session and
+      // its conversation/prompt state, when the real cause was a
+      // ~10-minute server-side idle timeout that resumeSession recovers
+      // from cleanly.
+      //
+      // A cwd change MUST still get a brand-new session via createSession,
+      // not resumeSession -- this isn't just a preference. The SDK's
+      // ResumeSessionConfig type has no workingDirectory field at all (only
+      // SessionConfig, used at creation, does): a session's working
+      // directory is fixed at creation time and cannot be changed on
+      // resume. Resuming across a cwd change would silently keep running
+      // tool calls against the session's *original* directory while our
+      // own SessionRecord.cwd bookkeeping claimed it had moved -- a real
+      // cross-workspace mismatch, not just a cosmetic one. A model-tier
+      // escalation is also treated as a fresh-session case for the same
+      // "deliberate context change, not a reconnect" reason, even though
+      // model itself isn't structurally blocked on resume the way cwd is.
+      //
       // Only fall back to createSession if resuming genuinely fails (e.g.
       // the underlying SDK session is truly unrecoverable) -- fail loud via
       // logging rather than silently masking a real dead-session case.
       let newSession: CopilotSession;
-      try {
-        newSession = await client.resumeSession(sessionId, createSessionOptions);
-      } catch (err) {
-        writeLog(`[Session] resumeSession(${sessionId}) failed, falling back to createSession: ${err}`, LogLevel.WARN);
+      if (!modelOrCwdChanged && realSessionId) {
+        try {
+          newSession = await client.resumeSession(realSessionId, createSessionOptions);
+        } catch (err) {
+          writeLog(`[Session] resumeSession(${realSessionId}) failed, falling back to createSession: ${err}`, LogLevel.WARN);
+          newSession = await client.createSession(createSessionOptions);
+        }
+      } else {
         newSession = await client.createSession(createSessionOptions);
       }
       const updated: SessionRecord = {

--- a/src/orchestrator/sessionState.ts
+++ b/src/orchestrator/sessionState.ts
@@ -168,11 +168,15 @@ export async function getOrCreateSession(
     if (modelOrCwdChanged || !existing.copilotSession) {
       writeLog(`[Session] Context mismatch or missing copilotSession detected for ${sessionId}. ${modelOrCwdChanged ? 'Recreating' : 'Resuming'} session context.`);
       // The real server-side Copilot session ID (a random UUID the SDK
-      // assigns) is only reachable via a *live* CopilotSession object's
-      // .sessionId -- it is never persisted to the DB and is NOT the same
-      // as `sessionId`, which is only the client-side activeSessions Map
-      // key. Capture it before disconnecting below.
-      const realSessionId = existing.copilotSession?.sessionId;
+      // assigns) is NOT the same as `sessionId`, which is only the
+      // client-side activeSessions Map key. It's captured from the live
+      // CopilotSession object whenever we have one, but it's also
+      // persisted to the DB (SessionRecord.copilotSessionId) precisely so
+      // it survives a disconnect or a rehydrate-from-DB (where
+      // copilotSession is null, see line ~148) -- otherwise the resume
+      // path below would be unreachable for exactly the cases it exists
+      // to handle.
+      const realSessionId = existing.copilotSession?.sessionId || existing.copilotSessionId;
       try {
         existing.unsubscribe?.();
         if (existing.copilotSession) {
@@ -220,6 +224,7 @@ export async function getOrCreateSession(
       const updated: SessionRecord = {
         sessionId,
         copilotSession: newSession,
+        copilotSessionId: newSession.sessionId,
         currentModel: safeModelTier,
         cwd,
         lastUsedAt: now,
@@ -252,6 +257,7 @@ export async function getOrCreateSession(
   const record: SessionRecord = {
     sessionId,
     copilotSession: newSession,
+    copilotSessionId: newSession.sessionId,
     currentModel: safeModelTier,
     cwd,
     lastUsedAt: now,

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -64,6 +64,12 @@ export interface SessionRecord {
   readonly sessionId: string;
   readonly taskId?: string;
   readonly copilotSession: CopilotSession | null;
+  // The SDK's real server-side session UUID (CopilotSession.sessionId).
+  // Unlike `copilotSession` (the live object, lost on disconnect/rehydrate),
+  // this is a plain string that gets persisted to the DB, so it survives a
+  // process restart or eviction from the in-memory activeSessions map and
+  // can still be used to resumeSession() afterwards.
+  readonly copilotSessionId?: string;
   readonly currentModel: ModelTier;
   readonly cwd: string;
   readonly lastUsedAt: number;


### PR DESCRIPTION
…… (#156)
…match (#154)

getOrCreateSession's 'context mismatch or missing copilotSession' branch previously called client.createSession() whenever a mapped session's copilotSession was missing/stale -- including the path hit after an UpstreamStreamStall retry. This was based on a wrong assumption that stalls were provider-side hangs; they're actually caused by a ~10-minute server-side idle timeout, so starting a brand-new session needlessly threw away conversation/prompt continuity.

Swap client.createSession() for client.resumeSession(sessionId, ...) in that branch, mirroring the resumeSession-based pattern already used by runForcedToolTurn for forced-tool-use retries. Falls back to createSession (with a WARN log) only if resuming genuinely fails, so a truly unrecoverable session still fails loud instead of silently masking a dead-session case.

gateLoop.ts's UpstreamStreamStall retry path already flows back through getOrCreateSession at the top of the while-loop body on 'continue', so no changes were needed there -- confirmed it does not go through the separate 'Creating fresh session' branch (which only fires when there is no sessionId at all).