### PR TITLE
fix(#154): resume server-side session ID, not client map key

### DIFF
--- a/src/orchestrator/sessionState.ts
+++ b/src/orchestrator/sessionState.ts
@@ -164,8 +164,15 @@ export async function getOrCreateSession(
   const safeModelTier = (MODEL_TIERS.includes(currentModel) ? currentModel : MODEL_TIERS[0]) || 'gemini-3.1-flash-lite';
 
   if (existing) {
-    if (existing.currentModel !== currentModel || existing.cwd !== cwd || !existing.copilotSession) {
-      writeLog(`[Session] Context mismatch or missing copilotSession detected for ${sessionId}. Resuming session context.`);
+    const modelOrCwdChanged = existing.currentModel !== currentModel || existing.cwd !== cwd;
+    if (modelOrCwdChanged || !existing.copilotSession) {
+      writeLog(`[Session] Context mismatch or missing copilotSession detected for ${sessionId}. ${modelOrCwdChanged ? 'Recreating' : 'Resuming'} session context.`);
+      // The real server-side Copilot session ID (a random UUID the SDK
+      // assigns) is only reachable via a *live* CopilotSession object's
+      // .sessionId -- it is never persisted to the DB and is NOT the same
+      // as `sessionId`, which is only the client-side activeSessions Map
+      // key. Capture it before disconnecting below.
+      const realSessionId = existing.copilotSession?.sessionId;
       try {
         existing.unsubscribe?.();
         if (existing.copilotSession) {
@@ -174,20 +181,40 @@ export async function getOrCreateSession(
       } catch (err) {
         writeLog(`[Session] Error disconnecting outdated session ${sessionId}: ${err}`);
       }
-      // `existing` means sessionId maps to a previously known session (either
-      // still in memory or rehydrated from the DB), so reconnect to it via
-      // resumeSession rather than starting a brand-new one -- this is what
-      // was actually causing loss of conversation/prompt continuity on
-      // stalls (see #154), which were misdiagnosed as provider-side hangs
-      // rather than the ~10-minute server-side idle timeout they really are.
+      // Only resume when the model/cwd are unchanged and we merely lost the
+      // live session object (e.g. after an UpstreamStreamStall retry, or a
+      // session rehydrated mid-flight) -- that's the actual stall/reconnect
+      // scenario this fixes (see #154): it was misdiagnosed as a
+      // provider-side hang and "fixed" by discarding the live session and
+      // its conversation/prompt state, when the real cause was a
+      // ~10-minute server-side idle timeout that resumeSession recovers
+      // from cleanly.
+      //
+      // A cwd change MUST still get a brand-new session via createSession,
+      // not resumeSession -- this isn't just a preference. The SDK's
+      // ResumeSessionConfig type has no workingDirectory field at all (only
+      // SessionConfig, used at creation, does): a session's working
+      // directory is fixed at creation time and cannot be changed on
+      // resume. Resuming across a cwd change would silently keep running
+      // tool calls against the session's *original* directory while our
+      // own SessionRecord.cwd bookkeeping claimed it had moved -- a real
+      // cross-workspace mismatch, not just a cosmetic one. A model-tier
+      // escalation is also treated as a fresh-session case for the same
+      // "deliberate context change, not a reconnect" reason, even though
+      // model itself isn't structurally blocked on resume the way cwd is.
+      //
       // Only fall back to createSession if resuming genuinely fails (e.g.
       // the underlying SDK session is truly unrecoverable) -- fail loud via
       // logging rather than silently masking a real dead-session case.
       let newSession: CopilotSession;
-      try {
-        newSession = await client.resumeSession(sessionId, createSessionOptions);
-      } catch (err) {
-        writeLog(`[Session] resumeSession(${sessionId}) failed, falling back to createSession: ${err}`, LogLevel.WARN);
+      if (!modelOrCwdChanged && realSessionId) {
+        try {
+          newSession = await client.resumeSession(realSessionId, createSessionOptions);
+        } catch (err) {
+          writeLog(`[Session] resumeSession(${realSessionId}) failed, falling back to createSession: ${err}`, LogLevel.WARN);
+          newSession = await client.createSession(createSessionOptions);
+        }
+      } else {
         newSession = await client.createSession(createSessionOptions);
       }
       const updated: SessionRecord = {


### PR DESCRIPTION
- Use existing.copilotSession.sessionId (the SDK's real server-side session UUID) for resumeSession, not the client-side activeSessions Map key that resumeSession was previously called with.
- Only attempt resume when model/cwd are unchanged and a live copilotSession (and thus a real server ID) exists; model or cwd changes still go through createSession since a session's cwd is fixed at creation time and a model/cwd change is a deliberate context change, not a reconnect.
- Falls back to createSession (with a WARN log) if resume fails.