### PR TITLE
Fix #155: fold retained conversation history into recreated sessions

### DIFF
--- a/src/orchestrator/sessionState.ts
+++ b/src/orchestrator/sessionState.ts
@@ -127,6 +127,62 @@ export const DIAGNOSTIC_SCENARIOS: Record<string, { gateSequence: boolean[], exe
   }
 };
 
+/**
+ * Folds retained `SessionRecord.conversationHistory` bookkeeping into the
+ * config passed to `client.createSession`, so a recreated session doesn't
+ * silently start with empty context at the SDK/model level (see #155).
+ *
+ * `createSession`/`resumeSession` have no `conversationHistory` field to
+ * populate directly -- resume avoids the problem entirely by continuing the
+ * SDK's own server-side history, but a genuine `createSession` fallback has
+ * no such continuity. The only config surface that reaches the model before
+ * the first turn is `systemMessage`, so the retained history is serialized
+ * into it there, mirroring the same "[Conversation History]" formatting
+ * already used ad hoc by `formatContextNarrowingPrompt`/`formatEscalationPrompt`
+ * for individual prompt strings.
+ *
+ * A no-op (returns `options` unchanged) when there's no history to carry
+ * forward, so callers with a brand-new session never pay for this.
+ */
+export function withRetainedHistory(
+  options: CopilotCreateSessionOptions,
+  history: SessionRecord['conversationHistory']
+): CopilotCreateSessionOptions {
+  if (!history || history.length === 0) {
+    return options;
+  }
+
+  const historyBlock = `\n\n[Retained Conversation History]\n${history
+    .map(h => `${h.role}: ${h.content}`)
+    .join('\n')}`;
+
+  const existingSystemMessage = options.systemMessage;
+
+  if (existingSystemMessage?.mode === 'replace') {
+    // Replace mode hands the model the caller's system message verbatim with
+    // no SDK-managed sections to fall back on -- appending here is the only
+    // way to still surface the retained history to a recreated session.
+    return {
+      ...options,
+      systemMessage: {
+        ...existingSystemMessage,
+        content: `${existingSystemMessage.content}${historyBlock}`,
+      },
+    };
+  }
+
+  // Append mode (the default when systemMessage is omitted) and customize
+  // mode both expose a plain `content` string that is added on top of the
+  // SDK-managed prompt, so the history block can simply be appended there.
+  return {
+    ...options,
+    systemMessage: {
+      ...existingSystemMessage,
+      content: `${existingSystemMessage?.content ?? ''}${historyBlock}`,
+    },
+  };
+}
+
 export async function getOrCreateSession(
   sessionId: string,
   currentModel: string,
@@ -216,10 +272,18 @@ export async function getOrCreateSession(
           newSession = await client.resumeSession(realSessionId, createSessionOptions);
         } catch (err) {
           writeLog(`[Session] resumeSession(${realSessionId}) failed, falling back to createSession: ${err}`, LogLevel.WARN);
-          newSession = await client.createSession(createSessionOptions);
+          // resumeSession would have carried the SDK's own server-side
+          // history forward; that continuity is lost the moment we fall
+          // back to createSession, so the retained bookkeeping history must
+          // be folded into the new session's config explicitly (see #155).
+          newSession = await client.createSession(withRetainedHistory(createSessionOptions, existing.conversationHistory));
         }
       } else {
-        newSession = await client.createSession(createSessionOptions);
+        // A cwd/model change (or no realSessionId to resume) means this is
+        // always a brand-new SDK session with no server-side history of its
+        // own -- fold the retained bookkeeping history into its config so it
+        // isn't silently dropped (see #155).
+        newSession = await client.createSession(withRetainedHistory(createSessionOptions, existing.conversationHistory));
       }
       const updated: SessionRecord = {
         sessionId,

--- a/src/test/withRetainedHistory.test.ts
+++ b/src/test/withRetainedHistory.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { withRetainedHistory, CopilotCreateSessionOptions } from '../orchestrator/sessionState';
+
+// Exercises withRetainedHistory in isolation: the pure config-merging step
+// that getOrCreateSession's createSession-fallback branch relies on to avoid
+// silently dropping conversation history (#155).
+describe('withRetainedHistory', () => {
+  const history = [
+    { role: 'user' as const, content: 'Build a login form.' },
+    { role: 'assistant' as const, content: 'Added LoginForm.tsx.' },
+  ];
+
+  it('returns the options unchanged when there is no history to carry forward', () => {
+    const options: CopilotCreateSessionOptions = { model: 'gemini-3.1-flash-lite' };
+    expect(withRetainedHistory(options, [])).toBe(options);
+  });
+
+  it('appends history into systemMessage.content when systemMessage is unset (default append mode)', () => {
+    const options: CopilotCreateSessionOptions = { model: 'gemini-3.1-flash-lite' };
+    const result = withRetainedHistory(options, history);
+
+    expect(result.systemMessage?.mode).toBeUndefined();
+    expect(result.systemMessage?.content).toContain('[Retained Conversation History]');
+    expect(result.systemMessage?.content).toContain('user: Build a login form.');
+    expect(result.systemMessage?.content).toContain('assistant: Added LoginForm.tsx.');
+    // Original options object must not be mutated.
+    expect(options.systemMessage).toBeUndefined();
+  });
+
+  it('appends history after existing content in append mode without discarding it', () => {
+    const options: CopilotCreateSessionOptions = {
+      systemMessage: { mode: 'append', content: 'Existing instructions.' },
+    };
+    const result = withRetainedHistory(options, history);
+
+    expect(result.systemMessage?.content).toContain('Existing instructions.');
+    expect(result.systemMessage?.content).toContain('[Retained Conversation History]');
+    expect(result.systemMessage?.content?.indexOf('Existing instructions.')).toBeLessThan(
+      result.systemMessage!.content!.indexOf('[Retained Conversation History]')
+    );
+  });
+
+  it('appends history after existing content in customize mode, preserving sections', () => {
+    const options: CopilotCreateSessionOptions = {
+      systemMessage: {
+        mode: 'customize',
+        sections: { environment_context: { action: 'remove' } },
+        content: 'Customize content.',
+      },
+    };
+    const result = withRetainedHistory(options, history);
+
+    expect(result.systemMessage?.mode).toBe('customize');
+    expect((result.systemMessage as any).sections).toEqual({ environment_context: { action: 'remove' } });
+    expect(result.systemMessage?.content).toContain('Customize content.');
+    expect(result.systemMessage?.content).toContain('[Retained Conversation History]');
+  });
+
+  it('appends history onto replace-mode content rather than dropping it', () => {
+    const options: CopilotCreateSessionOptions = {
+      systemMessage: { mode: 'replace', content: 'Full custom system message.' },
+    };
+    const result = withRetainedHistory(options, history);
+
+    expect(result.systemMessage?.mode).toBe('replace');
+    expect(result.systemMessage?.content).toContain('Full custom system message.');
+    expect(result.systemMessage?.content).toContain('[Retained Conversation History]');
+  });
+});


### PR DESCRIPTION
getOrCreateSession's recreate-session path called client.createSession with options that had no conversationHistory, so a genuinely new SDK session started with empty context even though SessionRecord.conversationHistory made it look like history had carried forward. Individual callers (e.g. the stall-retry path's formatContextNarrowingPrompt) patched around this ad hoc by reinjecting truncated history into the next prompt string, but not every caller of getOrCreateSession did that.

Add withRetainedHistory, which folds the retained conversationHistory into the createSession config's systemMessage.content (the only config surface that reaches the model before the first turn, since neither SessionConfig nor ResumeSessionConfig expose a conversationHistory field), and call it at both createSession fallback sites in the recreate branch. resumeSession is left untouched since it already continues the SDK's own server-side history.