### PR TITLE
Fix #208 review: keep curated systemMessage, carry it through resumeC…

### DIFF
--- a/src/utils/auditorHelper.ts
+++ b/src/utils/auditorHelper.ts
@@ -195,19 +195,19 @@ export function buildAuditorSessionSettings(
     // heartbeat during long reasoning turns without the token overhead of
     // "detailed". Models that don't support reasoning summaries ignore this.
     reasoningSummary: 'concise' as const,
-    // Deliberately NOT setting `systemMessage` here (see issue #208). It
-    // previously lived in the SDK-level system prompt via `mode: "replace"`,
-    // but that field is session-config-dependent: resumeSession()'s
-    // `resumeConfig` (toolCallEnforcement.ts) never carried it, so every
-    // stall/nudge-triggered resume silently dropped back to the SDK's
-    // *default* CLI system message instead of keeping ours -- both breaking
-    // the auditor's instructions and busting the prompt cache (a much
-    // larger default system prompt has to be reprocessed on every resume).
-    // The durable instructions (TOOL_USAGE_BOILERPLATE + systemPrompt) are
-    // now folded into the first-turn user prompt instead (see
-    // executeAuditSession below), which is part of conversation history and
-    // therefore survives resumeSession()/createSession() identically, with
-    // nothing session-config-dependent left to lose or regenerate.
+    // Explicit `replace` with our curated content -- NOT left unset. An
+    // unset/absent systemMessage makes the SDK fall back to its own full
+    // default `copilot-cli` system prompt (task/sub-agent, sql,
+    // report_intent, submit_code_review docs, etc.), which is exactly what
+    // TOOL_USAGE_BOILERPLATE's doc comment above says this session
+    // deliberately excludes. See issue #208: the original bug was that
+    // resumeSession()'s `resumeConfig` (toolCallEnforcement.ts) didn't
+    // carry this field, not that the field itself was wrong -- so the fix
+    // is to also pass it on resume, not drop it.
+    systemMessage: {
+        mode: "replace",
+        content: `${TOOL_USAGE_BOILERPLATE}\n\n${systemPrompt}`,
+    },
     tools: [
       {
         name: toolName,
@@ -295,13 +295,7 @@ export async function executeAuditSession<T>(
     sessionId = session.sessionId;
     onSessionId?.(session.sessionId);
 
-    // See the comment on buildAuditorSessionSettings: this used to be the
-    // SDK-level `systemMessage`, which resumeSession() would silently drop.
-    // Folding it into the first-turn prompt keeps it part of conversation
-    // history instead, so it survives every retry/resume path unchanged.
-    const promptWithInstructions = `${TOOL_USAGE_BOILERPLATE}\n\n${systemPrompt}\n\n${userPrompt}`;
-
-    const turnResult = await runForcedToolTurn(session, executionConfig, toolName, promptWithInstructions, {
+    const turnResult = await runForcedToolTurn(session, executionConfig, toolName, userPrompt, {
       client,
       abortSignal,
       timeoutMs,

--- a/src/utils/toolCallEnforcement.ts
+++ b/src/utils/toolCallEnforcement.ts
@@ -310,7 +310,7 @@ export async function runForcedToolTurn<T>(
    */
   const sendWithStallRetry = async (
     promptOpts: { prompt: string; tool_choice?: unknown },
-    resumeConfig: { availableTools?: string[]; tools?: unknown; provider?: ProviderConfig },
+    resumeConfig: { availableTools?: string[]; tools?: unknown; provider?: ProviderConfig; systemMessage?: SessionConfig['systemMessage'] },
   ): Promise<void> => {
     let stallAttempt = 0;
     let currentPromptOpts = promptOpts;
@@ -407,7 +407,7 @@ export async function runForcedToolTurn<T>(
     }
   };
 
-  await sendWithStallRetry({ prompt: initialPrompt }, { tools: opts.tools, ...(executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}) });
+  await sendWithStallRetry({ prompt: initialPrompt }, { tools: opts.tools, systemMessage: opts.freshSessionConfig?.systemMessage, ...(executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}) });
   
   let lastAssistantText = tracker.getText();
   tracker.unsubscribe();
@@ -433,6 +433,7 @@ export async function runForcedToolTurn<T>(
     const resumeConfig = {
       availableTools: targetTools,
       tools: opts.tools,
+      systemMessage: opts.freshSessionConfig?.systemMessage,
       ...(executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}),
     };
     


### PR DESCRIPTION
…onfig

Restore buildAuditorSessionSettings' explicit systemMessage: {mode: replace} block -- an absent systemMessage makes the SDK fall back to its full default CLI system prompt (task/sub-agent, sql, report_intent, submit_code_review docs), which is exactly what TOOL_USAGE_BOILERPLATE's doc comment says this session deliberately excludes.

Instead, thread systemMessage through toolCallEnforcement.ts's resumeConfig (both the initial-stall and nudge-retry resumeSession() calls), sourced from opts.freshSessionConfig.systemMessage, so the curated content survives resume instead of being dropped. Confirmed via auditSessionResume.test.ts telemetry: systemTokens now stays at the curated ~560 across initial and resumed turns (previously 5581, the full default).