### PR TITLE
Fix #207: Replace stall-watchdog recovery with a single hard timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,30 @@ kill pass keyed on an `EXEC_RUN_ID` marker to catch processes the group-kill can
 inside the container's PID namespace. If debugging a "still running after abort"
 report, check `processGroup.ts` and the container-side kill command in
 `dockerRunner.ts` first — this was a known gap, but is now handled.
+
+## Stall-watchdog recovery retired in favor of a single hard timeout
+
+`runForcedToolTurn`'s stall watchdog (`sendAndWaitWithAbort`'s 90s-silence
+threshold, `sendWithStallRetry`'s resume-then-fresh-session ladder) was built to
+recover from dead upstream connections. Every investigated case (PR #136, and a
+later PR-review session) turned out to be a slow-but-healthy turn -- long model
+reasoning, or one chaining many tool calls -- misdiagnosed as a stall, not an
+actual dead connection. Issues #188/#191 patched the watchdog to tolerate silence
+during active tool *execution*, but silence during model reasoning/generation (the
+observed pattern, `lastEventType=session.usage_info`) has no reliable SDK signal to
+distinguish from a real stall. Recovering from a false positive also has its own
+cost: `resumeSession()` re-injects the SDK's default system message and busts the
+prompt cache (issue #208), making the "recovered" turn slower -- which can itself
+look like a second stall.
+
+`runForcedToolTurnUntilTimeout` (`toolCallEnforcement.ts`) is now the path all
+callers use: same tool-not-called nudge/retry loop as `runForcedToolTurn`, but a
+single hard timeout racing `sendAndWait` directly, with no watchdog and no
+mid-turn resume. `executeAuditSession` (`auditorHelper.ts`) and all three
+`gateLoop.ts` forced-tool-turn call sites use it.
+
+`runForcedToolTurn`, `sendAndWaitWithAbort`, `STALL_TIMEOUT_MS`, `isStallError`,
+and their three existing test files are intentionally left in place, dormant, not
+deleted -- **do not delete them as part of unrelated cleanup.** If a genuine stall
+is ever observed independently of turn duration, that's the code to reach for
+again.

--- a/src/orchestrator/gateLoop.ts
+++ b/src/orchestrator/gateLoop.ts
@@ -43,7 +43,7 @@ import {
   COMPOSER_ROUTER_TOOL,
   AMBIGUITY_CHECK_TOOL,
 } from "../config/tools";
-import { runForcedToolTurn } from "../utils/toolCallEnforcement";
+import { runForcedToolTurnUntilTimeout } from "../utils/toolCallEnforcement";
 import {
   normalizeGates,
   TASK_TYPE_GATE_MAP,
@@ -1116,7 +1116,7 @@ export const handleGateLoop = async (
 
           let clarityData: ClarityCheckData | null = null;
           // NOTE: attached via onSession below (not just on `claritySession`), because
-          // runForcedToolTurn's nudge retry calls client.resumeSession() internally,
+          // runForcedToolTurnUntilTimeout's nudge retry calls client.resumeSession() internally,
           // which returns a brand-new CopilotSession object. A listener bound only to
           // the original `claritySession` would silently miss the tool call if the
           // model only complies on the retry.
@@ -1154,10 +1154,10 @@ export const handleGateLoop = async (
           };
           abortController.signal.addEventListener("abort", clarityAbortHandler);
           let clarityRunResult:
-            | Awaited<ReturnType<typeof runForcedToolTurn>>
+            | Awaited<ReturnType<typeof runForcedToolTurnUntilTimeout>>
             | undefined;
           try {
-            const runPromise = runForcedToolTurn(
+            const runPromise = runForcedToolTurnUntilTimeout(
               claritySession,
               clarityConfig,
               "submit_clarity_check",
@@ -1186,7 +1186,7 @@ export const handleGateLoop = async (
             clarityRunResult = (await Promise.race([
               runPromise,
               abortPromise,
-            ])) as Awaited<ReturnType<typeof runForcedToolTurn>> | undefined;
+            ])) as Awaited<ReturnType<typeof runForcedToolTurnUntilTimeout>> | undefined;
           } finally {
             abortController.signal.removeEventListener(
               "abort",
@@ -1274,7 +1274,7 @@ export const handleGateLoop = async (
             });
           let toolArguments: ComposerRouteArguments | null = null;
           // NOTE: attached via onSession below (not just on `classificationSession`),
-          // because runForcedToolTurn's nudge retry calls client.resumeSession()
+          // because runForcedToolTurnUntilTimeout's nudge retry calls client.resumeSession()
           // internally, which returns a brand-new CopilotSession object. A listener
           // bound only to the original `classificationSession` would silently miss
           // the tool call if the model only complies on the retry.
@@ -1313,7 +1313,7 @@ export const handleGateLoop = async (
           );
           try {
             // Force the tool choice to guarantee a structured plan
-            const runPromise = runForcedToolTurn(
+            const runPromise = runForcedToolTurnUntilTimeout(
               classificationSession,
               classificationConfig,
               "initialize_blueprint",
@@ -2395,7 +2395,7 @@ export const handleGateLoop = async (
                 );
                 try {
                   const retryResult = (await Promise.race([
-                    runForcedToolTurn(
+                    runForcedToolTurnUntilTimeout(
                       session,
                       loopExecutionConfig,
                       (loopSessionOptions.tools
@@ -2429,7 +2429,7 @@ export const handleGateLoop = async (
                   if (retryResult) {
                     if (retryResult.session) {
                       session = retryResult.session;
-                      // `runForcedToolTurn` may have resumed into a brand-new
+                      // `runForcedToolTurnUntilTimeout` may have resumed into a brand-new
                       // CopilotSession object (client.resumeSession() returns a
                       // different handle than the one passed in). The next loop
                       // iteration's getOrCreateSession() reads the cached

--- a/src/test/executeAuditSessionStallDisconnect.test.ts
+++ b/src/test/executeAuditSessionStallDisconnect.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { STALL_TIMEOUT_MS } from '../utils/toolCallEnforcement';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 interface SessionDouble {
   sessionId: string;
@@ -9,16 +8,11 @@ interface SessionDouble {
 }
 
 // Session doubles created by the mocked CopilotClient below, in creation
-// order, so assertions can address "the first (stalled) session" vs "the
-// final session" without guessing ids.
+// order.
 let sessionsCreated: SessionDouble[] = [];
 
-function makeSessionDouble(behavior: 'stall' | 'succeed'): SessionDouble {
+function makeSessionDouble(): SessionDouble {
   const id = `session-${sessionsCreated.length + 1}`;
-  // Real CopilotSession.on() supports many concurrent listeners (stall
-  // tracker, assistant-text tracker, tool-call tracker all subscribe
-  // independently) -- a single-slot mock would let later subscribers
-  // silently clobber earlier ones.
   const listeners: Array<(event: unknown) => void> = [];
   const emit = (event: unknown) => listeners.forEach((cb) => cb(event));
   const session = {
@@ -31,13 +25,13 @@ function makeSessionDouble(behavior: 'stall' | 'succeed'): SessionDouble {
       });
     }),
     sendAndWait: vi.fn().mockImplementation(() => {
-      if (behavior === 'stall') {
-        // Never resolves and never emits an event -- the exact "upstream
-        // stream stalled" shape sendAndWaitWithAbort's watchdog exists for.
-        return new Promise(() => {});
-      }
       // A healthy turn: the model calls the target tool, then the send
-      // resolves.
+      // resolves. executeAuditSession no longer routes through
+      // runForcedToolTurn's stall watchdog/resume ladder (issue #207 --
+      // it now uses runForcedToolTurnUntilTimeout, which has neither), so
+      // there is no "stall" leg to model here anymore. The stall-specific
+      // disconnect regression (issue #186/#187) is still covered directly
+      // against the dormant `runForcedToolTurn` in toolCallEnforcement.test.ts.
       emit({ type: 'tool.execution_start', data: { toolName: 'submit_finding' } });
       return Promise.resolve();
     }),
@@ -56,12 +50,10 @@ vi.mock('../copilotSdk/boundary', () => {
     async start() {}
     async stop() {}
     async createSession(_config: unknown) {
-      // First session this run ever creates is the one that stalls; any
-      // session created after that (i.e. the stall-recovery session) succeeds.
-      return makeSessionDouble(sessionsCreated.length === 0 ? 'stall' : 'succeed');
+      return makeSessionDouble();
     }
     async resumeSession(_id: string, _config: unknown) {
-      return makeSessionDouble('succeed');
+      return makeSessionDouble();
     }
   }
   return { CopilotClient: MockCopilotClient };
@@ -69,17 +61,12 @@ vi.mock('../copilotSdk/boundary', () => {
 
 import { executeAuditSession, ToolDefinition } from '../utils/auditorHelper';
 
-describe('executeAuditSession: stalled sessions are always disconnected (issue #187)', () => {
+describe('executeAuditSession: session is always disconnected once the turn completes', () => {
   beforeEach(() => {
     sessionsCreated = [];
-    vi.useFakeTimers();
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it('disconnects the stalled session as well as the final session by the time executeAuditSession returns', async () => {
+  it('disconnects the session used for a successful turn (issue #187, updated for issue #207)', async () => {
     const tool: ToolDefinition = {
       function: {
         name: 'submit_finding',
@@ -92,7 +79,7 @@ describe('executeAuditSession: stalled sessions are always disconnected (issue #
       },
     };
 
-    const runPromise = executeAuditSession(
+    const result = await executeAuditSession(
       '/tmp/does-not-matter',
       {} as any,
       'You are an auditor.',
@@ -105,30 +92,8 @@ describe('executeAuditSession: stalled sessions are always disconnected (issue #
       2,
     );
 
-    // Let the stall watchdog on the first (createSession) session's
-    // sendAndWait fire, then let the resumed session's send resolve.
-    await vi.advanceTimersByTimeAsync(STALL_TIMEOUT_MS + 5000);
-
-    const result = await runPromise;
     expect(result).toBeTruthy();
-
-    // Two sessions should have been produced: the one that stalled and the
-    // one that recovered via resumeSession and actually called the tool.
-    expect(sessionsCreated.length).toBe(2);
-    const stalledSession = sessionsCreated[0]!;
-    const finalSession = sessionsCreated[1]!;
-
-    // The final session's disconnect is already implicitly required for
-    // executeAuditSession to clean up after a successful run.
-    expect(finalSession.disconnect).toHaveBeenCalledTimes(1);
-
-    // The actual regression this test guards against: before the fix in
-    // runForcedToolTurn's sendWithStallRetry (toolCallEnforcement.ts:359),
-    // the stalled session was dropped without ever calling disconnect(),
-    // leaking a live connection every time a stall triggered recovery.
-    // This is the same leak issue #186 covers at the runForcedToolTurn unit
-    // level; this asserts it holds through the full executeAuditSession
-    // integration as well.
-    expect(stalledSession.disconnect).toHaveBeenCalledTimes(1);
+    expect(sessionsCreated.length).toBe(1);
+    expect(sessionsCreated[0]!.disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/test/toolCallEnforcementUntilTimeout.test.ts
+++ b/src/test/toolCallEnforcementUntilTimeout.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runForcedToolTurnUntilTimeout, FORCED_TOOL_TURN_HARD_TIMEOUT_MS } from '../utils/toolCallEnforcement';
+
+describe('runForcedToolTurnUntilTimeout', () => {
+  it('no-tool-call -> retry once with availableTools narrowed and tool_choice set; exhausts retries -> throws', async () => {
+    let callCount = 0;
+    const mockSession = {
+      sessionId: 'test-session',
+      on: vi.fn().mockReturnValue(vi.fn()),
+      sendAndWait: vi.fn().mockImplementation(async (opts) => {
+        callCount++;
+        if (callCount === 2) {
+          expect(opts.tool_choice).toEqual({ type: 'function', function: { name: 'my_tool' } });
+        }
+      }),
+    } as any;
+
+    const mockClient = {
+      resumeSession: vi.fn().mockImplementation(async (id, opts) => {
+        expect(opts.availableTools).toEqual(['my_tool']);
+        return mockSession;
+      }),
+    } as any;
+
+    const runPromise = runForcedToolTurnUntilTimeout(mockSession, { provider: 'openrouter' }, 'my_tool', 'test prompt', {
+      client: mockClient,
+      maxRetries: 1,
+      getResult: () => null,
+      tools: [],
+    });
+
+    await expect(runPromise).rejects.toThrow(/Session ended without calling 'my_tool' after 1 retry/);
+    expect(callCount).toBe(2);
+    expect(mockClient.resumeSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves once the target tool fires, without any resume', async () => {
+    const mockSession = {
+      sessionId: 's1',
+      on: vi.fn().mockImplementation((handler) => {
+        handler({ type: 'tool.execution_start', data: { toolName: 'my_tool' } });
+        return vi.fn();
+      }),
+      sendAndWait: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    const mockClient = { resumeSession: vi.fn() } as any;
+
+    const result = await runForcedToolTurnUntilTimeout(mockSession, {}, 'my_tool', 'test prompt', {
+      client: mockClient,
+      getResult: () => ({ ok: true }),
+    });
+
+    expect(result.toolCalled).toBe(true);
+    expect(result.result).toEqual({ ok: true });
+    expect(mockClient.resumeSession).not.toHaveBeenCalled();
+  });
+
+  it('passes timeoutMs straight through to sendAndWait (no watchdog ceiling applied)', async () => {
+    const mockSession = {
+      sessionId: 's2',
+      on: vi.fn().mockImplementation((handler) => {
+        handler({ type: 'tool.execution_start', data: { toolName: 'my_tool' } });
+        return vi.fn();
+      }),
+      sendAndWait: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await runForcedToolTurnUntilTimeout(mockSession, {}, 'my_tool', 'test prompt', {
+      client: { resumeSession: vi.fn() } as any,
+      timeoutMs: 42,
+      getResult: () => null,
+    });
+
+    expect(mockSession.sendAndWait).toHaveBeenCalledWith({ prompt: 'test prompt' }, 42);
+  });
+
+  it('defaults timeoutMs to FORCED_TOOL_TURN_HARD_TIMEOUT_MS (60 min) when unset', async () => {
+    const mockSession = {
+      sessionId: 's3',
+      on: vi.fn().mockImplementation((handler) => {
+        handler({ type: 'tool.execution_start', data: { toolName: 'my_tool' } });
+        return vi.fn();
+      }),
+      sendAndWait: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await runForcedToolTurnUntilTimeout(mockSession, {}, 'my_tool', 'test prompt', {
+      client: { resumeSession: vi.fn() } as any,
+      getResult: () => null,
+    });
+
+    expect(FORCED_TOOL_TURN_HARD_TIMEOUT_MS).toBe(60 * 60 * 1000);
+    expect(mockSession.sendAndWait).toHaveBeenCalledWith({ prompt: 'test prompt' }, FORCED_TOOL_TURN_HARD_TIMEOUT_MS);
+  });
+
+  it('rejects on abort signal without touching resumeSession', async () => {
+    const abortController = new AbortController();
+    const mockSession = {
+      sessionId: 's4',
+      on: vi.fn().mockReturnValue(vi.fn()),
+      sendAndWait: vi.fn().mockImplementation(() => new Promise(() => {})), // never resolves
+    } as any;
+    const mockClient = { resumeSession: vi.fn() } as any;
+
+    const runPromise = runForcedToolTurnUntilTimeout(mockSession, {}, 'my_tool', 'test prompt', {
+      client: mockClient,
+      abortSignal: abortController.signal,
+      getResult: () => null,
+    });
+
+    abortController.abort();
+
+    await expect(runPromise).rejects.toThrow(/aborted/);
+    expect(mockClient.resumeSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/auditorHelper.ts
+++ b/src/utils/auditorHelper.ts
@@ -1,4 +1,4 @@
-import { runForcedToolTurn } from './toolCallEnforcement';
+import { runForcedToolTurnUntilTimeout } from './toolCallEnforcement';
 import { CopilotClient, SdkProviderConfig, SessionConfig, CopilotSession, PermissionRequest, PermissionRequestResult } from '../copilotSdk/boundary';
 import { ProviderRegistry, ExecutionConfig } from './providerRegistry';
 import { DEFAULT_ROLES_CONFIG, getAuditorTierConfig } from '../config/models';
@@ -295,7 +295,7 @@ export async function executeAuditSession<T>(
     sessionId = session.sessionId;
     onSessionId?.(session.sessionId);
 
-    const turnResult = await runForcedToolTurn(session, executionConfig, toolName, userPrompt, {
+    const turnResult = await runForcedToolTurnUntilTimeout(session, executionConfig, toolName, userPrompt, {
       client,
       abortSignal,
       timeoutMs,
@@ -303,7 +303,6 @@ export async function executeAuditSession<T>(
       getResult: () => result,
       tools: sessionSettings.tools,
       responseRequirements,
-      freshSessionConfig: sessionSettings as SessionConfig & { autoApproveAll?: boolean },
       onSessionId: (id) => {
         sessionId = id;
         onSessionId?.(id);

--- a/src/utils/toolCallEnforcement.ts
+++ b/src/utils/toolCallEnforcement.ts
@@ -478,3 +478,184 @@ export async function runForcedToolTurn<T>(
   
   return { result: finalResult as T, session: currentSession, lastAssistantText, toolCalled };
 }
+
+/**
+ * Default hard timeout for `runForcedToolTurn`'s "no watchdog" successor,
+ * `runForcedToolTurnUntilTimeout` -- see that function's doc comment. 60
+ * minutes is generous headroom for a legitimately long, healthy,
+ * reasoning-heavy turn (many chained tool calls) -- the exact case that
+ * made the old stall watchdog's 90s-silence heuristic unreliable (see
+ * `STALL_TIMEOUT_MS`'s doc comment and issues #188/#191).
+ */
+export const FORCED_TOOL_TURN_HARD_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
+
+/**
+ * Same options shape as `ForcedToolTurnOptions`, minus the stall-specific
+ * knobs (`maxStallRetries`, `freshSessionConfig`) that don't apply here --
+ * there is no stall detection or stall recovery in this function, so
+ * nothing consumes them.
+ */
+export type ForcedToolTurnUntilTimeoutOptions<T> = Omit<
+  ForcedToolTurnOptions<T>,
+  'maxStallRetries' | 'freshSessionConfig'
+>;
+
+/**
+ * Successor to `runForcedToolTurn` for callers that don't need stall
+ * recovery. Retired per issue #207: every investigated "stall" (PR #136,
+ * and a subsequent PR-review session) turned out to be a slow-but-healthy
+ * turn -- a long reasoning pass, or one chaining many tool calls --
+ * misdiagnosed as a dead upstream connection, not an actual dead
+ * connection. Issues #188/#191 patched the watchdog to tolerate silence
+ * during active tool *execution*, but silence during model
+ * reasoning/generation (the actual observed pattern, `lastEventType`
+ * landing on `session.usage_info`) has no reliable SDK signal to
+ * distinguish from a real stall, so the watchdog kept false-positiving on
+ * it. Recovering from a false positive via `resumeSession()` also carries
+ * its own cost independent of correctness: it re-injects the SDK's default
+ * system message and busts the prompt cache (issue #208), making the
+ * "recovered" turn slower and more expensive -- which can itself look like
+ * a second stall.
+ *
+ * This function keeps the tool-not-called nudge/retry loop from
+ * `runForcedToolTurn` unchanged, but replaces the idle-silence watchdog
+ * and mid-turn stall-recovery ladder (resume-then-fresh-session) with a
+ * single hard timeout racing `session.sendAndWait` directly -- if the SDK
+ * hasn't resolved by `timeoutMs` (default `FORCED_TOOL_TURN_HARD_TIMEOUT_MS`),
+ * the turn fails outright rather than being torn down and retried
+ * mid-flight. No resume, no fresh session, no stall-specific retry budget.
+ *
+ * `runForcedToolTurn`, `sendAndWaitWithAbort`, `STALL_TIMEOUT_MS`,
+ * `isStallError`, and their existing tests are left in place, dormant, not
+ * deleted -- see AGENTS.md. If a genuine (not turn-duration-driven) stall
+ * is ever observed independently of this, that's the code to reach for
+ * again.
+ */
+export async function runForcedToolTurnUntilTimeout<T>(
+  session: CopilotSession,
+  executionConfig: { provider?: unknown },
+  toolName: string | string[],
+  initialPrompt: string,
+  opts: ForcedToolTurnUntilTimeoutOptions<T>
+): Promise<{ result: T; session: CopilotSession; lastAssistantText: string; toolCalled: boolean }> {
+  let currentSession = session;
+  let currentSessionId = session.sessionId;
+  const timeoutMs = opts.timeoutMs ?? FORCED_TOOL_TURN_HARD_TIMEOUT_MS;
+  const maxRetries = opts.maxRetries ?? 2;
+  const responseRequirements = opts.responseRequirements ?? {};
+
+  let toolCalled = false;
+  const targetTools = Array.isArray(toolName) ? toolName : [toolName];
+  let tracker = trackLastAssistantMessage(currentSession);
+
+  const setupToolListener = (s: CopilotSession) => {
+    const unsub = s.on((event: unknown) => {
+      const ev = event as Record<string, unknown>;
+      if (
+        (ev.type === 'tool.user_requested' && targetTools.includes((ev.data as any)?.toolName)) ||
+        (ev.type === 'tool.execution_start' && targetTools.includes((ev.data as any)?.toolName)) ||
+        (ev.type === 'external_tool.requested' && targetTools.includes((ev.data as any)?.toolName)) ||
+        (ev.type === 'tool.execution_complete' && (ev.data as any)?.toolCallId && targetTools.some(t => (ev.data as any).toolCallId === `call-${t}`)) ||
+        (ev.type === 'tool.execution_complete' && targetTools.includes((ev.data as any)?.toolName))
+      ) {
+        toolCalled = true;
+      }
+    });
+    return unsub;
+  };
+
+  let unsubTool = setupToolListener(currentSession);
+  let unsubOnSession = opts.onSession?.(currentSession) ?? undefined;
+
+  /**
+   * Races the SDK's own `sendAndWait` against the caller's abort signal
+   * only -- no idle-silence watchdog, no stall-tagged rejection, no
+   * mid-turn resume. A hang here surfaces as the plain timeout/abort
+   * rejection `sendAndWait` (or the abort listener) throws.
+   */
+  const sendUntilTimeout = async (promptOpts: MessageOptions): Promise<void> => {
+    const racers: Promise<void>[] = [
+      currentSession.sendAndWait(promptOpts, timeoutMs).then(() => undefined),
+    ];
+    if (opts.abortSignal) {
+      racers.push(
+        new Promise<never>((_, reject) => {
+          const onAbort = () => reject(new Error('Auditor session aborted by client or timeout'));
+          if (opts.abortSignal!.aborted) onAbort();
+          else opts.abortSignal!.addEventListener('abort', onAbort, { once: true });
+        }),
+      );
+    }
+    await Promise.race(racers);
+  };
+
+  await sendUntilTimeout({ prompt: initialPrompt } as MessageOptions);
+
+  let lastAssistantText = tracker.getText();
+  tracker.unsubscribe();
+  unsubTool();
+
+  let attempt = 0;
+
+  while (!toolCalled && attempt < maxRetries) {
+    attempt++;
+    const toolNamesStr = targetTools.map(t => `'${t}'`).join(' or ');
+    console.warn(
+      `[runForcedToolTurnUntilTimeout] turn ended without ${toolNamesStr} being called ` +
+      `(attempt ${attempt}/${maxRetries}); resuming session with restricted toolset...`
+    );
+
+    const exampleBlock = responseRequirements.toolCallExample
+      ? `\n\nUse your tool-calling capability (a real function/tool call) -- not text in your message. Example of correctly-shaped arguments:\n\n${responseRequirements.toolCallExample}`
+      : '';
+    const nudge = lastAssistantText.trim()
+      ? `You did not call any of: ${toolNamesStr}. Your last message was:\n"""\n${truncate(lastAssistantText.trim(), LAST_MESSAGE_TRUNCATE_LENGTH)}\n"""\nYou must now call one of ${toolNamesStr} with your findings. Do not respond conversationally, do not ask clarifying questions, and do not call any other tool -- call one of ${toolNamesStr} now.${exampleBlock}`
+      : `You ended your turn without calling any of: ${toolNamesStr}. You must now call one of ${toolNamesStr} with your findings. Do not respond conversationally and do not call any other tool -- call one of ${toolNamesStr} now.${exampleBlock}`;
+
+    const resumeConfig = {
+      availableTools: targetTools,
+      tools: opts.tools,
+      systemMessage: undefined as SessionConfig['systemMessage'],
+      ...(executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}),
+    };
+
+    currentSession = await opts.client.resumeSession(currentSessionId, resumeConfig);
+    currentSessionId = currentSession.sessionId;
+    opts.onSessionId?.(currentSessionId);
+
+    unsubOnSession?.();
+    tracker = trackLastAssistantMessage(currentSession);
+    toolCalled = false;
+    unsubTool = setupToolListener(currentSession);
+    unsubOnSession = opts.onSession?.(currentSession) ?? undefined;
+
+    const promptOpts: { prompt: string; tool_choice?: unknown } = { prompt: nudge, tool_choice: undefined as any };
+    if (executionConfig.provider === 'openrouter') {
+      promptOpts.tool_choice = { type: 'function', function: { name: targetTools[0] } };
+    }
+
+    await sendUntilTimeout(promptOpts as MessageOptions);
+
+    lastAssistantText = tracker.getText() || lastAssistantText;
+    tracker.unsubscribe();
+    unsubTool();
+  }
+
+  unsubOnSession?.();
+
+  if (!toolCalled) {
+    const toolNamesStr = targetTools.map(t => `'${t}'`).join(' or ');
+    const truncated = truncate(lastAssistantText.trim(), LAST_MESSAGE_TRUNCATE_LENGTH);
+    throw new Error(
+      `Session ended without calling ${toolNamesStr} after ${maxRetries} retr${maxRetries === 1 ? 'y' : 'ies'}. ` +
+      `Model's last message: ${truncated || '(no assistant text captured)'}`
+    );
+  }
+
+  let finalResult = opts.getResult();
+  if (toolCalled && (finalResult === null || finalResult === undefined)) {
+    finalResult = (true as unknown) as T;
+  }
+
+  return { result: finalResult as T, session: currentSession, lastAssistantText, toolCalled };
+}


### PR DESCRIPTION
Add runForcedToolTurnUntilTimeout to toolCallEnforcement.ts: same tool-not-called nudge/retry loop as runForcedToolTurn, but a single hard timeout (default 60min) racing sendAndWait directly -- no idle-silence watchdog, no mid-turn resume/fresh-session recovery.

Switch all current callers onto it: executeAuditSession (auditorHelper.ts) and all three gateLoop.ts forced-tool-turn call sites.

Leave runForcedToolTurn, sendAndWaitWithAbort, STALL_TIMEOUT_MS, isStallError, and their existing unit test files untouched -- dormant, not deleted. Update executeAuditSessionStallDisconnect.test.ts, which integration-tested executeAuditSession's now-removed stall-recovery path, to cover the current no-stall disconnect behavior instead (the stall-specific disconnect regression is still covered directly against the dormant runForcedToolTurn in toolCallEnforcement.test.ts).

Document the retirement, the dormant-code rationale, and the do-not-delete instruction in AGENTS.md.