### PR TITLE
Fix #79: don't forward Implementor/Gemini key to non-Gemini auditor p…

### DIFF
--- a/src/test/auditor_pool_rotation.test.ts
+++ b/src/test/auditor_pool_rotation.test.ts
@@ -155,4 +155,33 @@ describe('selectRotatingAuditorConfig (Issue 79 / RM-REQ-030/031/032)', () => {
       expect(selection.nextRotationIndex).toBe(i + 1);
     }
   });
+
+  describe('cross-provider pool key resolution (regression: does not forward the Implementor/Gemini key to non-Gemini entries)', () => {
+    beforeEach(() => {
+      process.env.AUDITOR_POOL = 'gemini:gemini-3.1-flash-lite,openai:gpt-4o-mini';
+      process.env.OPENAI_API_KEY = 'test-openai-key';
+      process.env.GEMINI_API_KEY = 'test-gemini-key';
+      vi.resetModules();
+    });
+
+    it('does not forward the caller-supplied (Implementor/Gemini) apiKey to a rotated-in non-Gemini pool entry', async () => {
+      const { selectRotatingAuditorConfig } = await import('../utils/auditorHelper');
+      // rotationIndex 1 selects the openai:gpt-4o-mini pool entry.
+      const selection = selectRotatingAuditorConfig(1, 'implementor-gemini-key');
+
+      expect(selection.executionConfig.providerType).toBe('openai');
+      // Must resolve via OPENAI_API_KEY, never the Gemini key passed in by the caller.
+      expect(selection.executionConfig.provider?.apiKey).toBe('test-openai-key');
+      expect(selection.executionConfig.provider?.apiKey).not.toBe('implementor-gemini-key');
+    });
+
+    it('still forwards the caller-supplied apiKey when the rotated-in entry is actually Gemini', async () => {
+      const { selectRotatingAuditorConfig } = await import('../utils/auditorHelper');
+      // rotationIndex 0 selects the gemini:gemini-3.1-flash-lite pool entry.
+      const selection = selectRotatingAuditorConfig(0, 'implementor-gemini-key');
+
+      expect(selection.executionConfig.model).toBe('gemini-3.1-flash-lite');
+      expect(selection.executionConfig.providerType).toBe('gemini');
+    });
+  });
 });

--- a/src/utils/auditorHelper.ts
+++ b/src/utils/auditorHelper.ts
@@ -174,7 +174,18 @@ export function selectRotatingAuditorConfig(rotationIndex: number, apiKey?: stri
   }
   const normalizedIndex = ((rotationIndex % pool.length) + pool.length) % pool.length;
   const auditorConfig = selectFromAuditorPool(normalizedIndex);
-  const executionConfig = resolveExecutionConfig(auditorConfig, 'auditor pool', apiKey);
+
+  // The `apiKey` passed in here originates upstream as the Implementor's key,
+  // which is always a Gemini key (gateLoop's `keyToUse = apiKey ||
+  // process.env.GEMINI_API_KEY`). For a multi-provider pool
+  // (e.g. AUDITOR_POOL=gemini:...,openai:gpt-4o-mini), forwarding that key
+  // verbatim into resolveExecutionConfig for a non-Gemini selection would
+  // send the wrong provider's API key and break auth. Only forward it when
+  // the selected pool entry is actually a Gemini entry; otherwise let
+  // resolveExecutionConfig fall back to that provider's own env var
+  // (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.).
+  const keyForSelectedProvider = auditorConfig.provider === 'gemini' ? apiKey : undefined;
+  const executionConfig = resolveExecutionConfig(auditorConfig, 'auditor pool', keyForSelectedProvider);
 
   return {
     executionConfig,


### PR DESCRIPTION
…ool entries

selectRotatingAuditorConfig was passing the caller-supplied apiKey (always the Implementor's Gemini key, per gateLoop's keyToUse = apiKey || process.env.GEMINI_API_KEY) straight into resolveExecutionConfig regardless of which provider the rotation pool selected. For a multi-provider AUDITOR_POOL (e.g.
gemini:...,openai:gpt-4o-mini), rotating into the openai entry sent the Gemini key as the OpenAI credential, breaking auth.

Only forward the caller-supplied key when the selected pool entry is actually a Gemini entry; otherwise let resolveExecutionConfig fall back to that provider's own env var (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.), matching how getAuditorExecutionConfig and getReviewerExecutionConfig already resolve keys per-provider.

Adds regression tests covering both the non-Gemini rotation (key not forwarded, falls back to OPENAI_API_KEY) and the Gemini rotation (key still forwarded).