### PR TITLE
Fix #221: document run-issue-task.ts's executeAuditSession gap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,9 +117,15 @@ correct. The fix was to also pass it on resume, not to change the field.
 
 This is a general SDK usage rule, not specific to PR review or to
 `executeAuditSession` -- it applies to **any** future caller that resumes a
-session directly, including retry/resume logic that might later be added to
-`run-issue-task.ts` (which does not resume sessions today, but would need this
-the moment it does).
+session directly. `run-issue-task.ts` (see the issue #221 tracking comment near
+its `PORT` constant) is one such caller: it goes through
+`runForcedToolTurnUntilTimeout` directly rather than through
+`executeAuditSession`, and already forwards `systemMessage` in its retry
+config, so it isn't currently exposed to the #208 failure mode. It also still
+lacks the rest of `executeAuditSession`'s accumulated protections (the
+nudge/retry loop's other edge cases from #188/#191/#207, and any future
+watchdog/mid-turn-resume work) -- re-verify it against those issues before
+assuming full parity if this script's session handling changes.
 
 ## Execution-aware silence tracking
 

--- a/scripts/run-issue-task.ts
+++ b/scripts/run-issue-task.ts
@@ -18,6 +18,15 @@ import {
   RUN_GH_COMMAND_TOOL_NAME,
 } from './tools/agentGhTool';
 
+// SDK-nuance tracking (issue #221): unlike `executeAuditSession` (auditorHelper.ts),
+// this script calls `runForcedToolTurnUntilTimeout` directly rather than through that
+// wrapper. It does already forward `systemMessage` into the retry/resume config below
+// (the #208 fix -- see AGENTS.md's "Execution-aware silence tracking" section for the
+// history), so a mid-run resume here should not silently drop the session's system
+// prompt the way it once did for `executeAuditSession`. If this script grows other
+// audit-session behavior (e.g. adopting `executeAuditSession` itself, or adding
+// watchdog/mid-turn-resume logic), re-check it against the protections tracked in
+// issues #188/#191/#207/#208 before assuming parity.
 const PORT = parseInt(process.env.PORT || '3000', 10);
 
 /**


### PR DESCRIPTION
Adds a comment in run-issue-task.ts and updates the stale note in AGENTS.md's 'Execution-aware silence tracking' section. The script already calls runForcedToolTurnUntilTimeout directly (not via executeAuditSession) and already forwards systemMessage in its retry config, so it isn't exposed to the #208 systemMessage-drop failure mode. It still lacks the rest of executeAuditSession's accumulated protections from #188/#191/#207, which is now tracked explicitly and linked forward from both files.