### PR TITLE
Fix #246: Implement hardened resume logic

### DIFF
--- a/src/copilotSdk/hardenedSession.ts
+++ b/src/copilotSdk/hardenedSession.ts
@@ -166,3 +166,76 @@ export async function createHardenedSession(
   policyBySessionId.set(session.sessionId, policy);
   return session;
 }
+
+/**
+ * Binds `policy` to `sessionId` without going through `createHardenedSession`.
+ *
+ * Exists for sessions that predate the hardened wrapper -- e.g. the sessions
+ * `runForcedToolTurn`/`runForcedToolTurnUntilTimeout` in
+ * `toolCallEnforcement.ts` receive as an argument, already created by their
+ * caller. Migrating those call sites to `createHardenedSession` outright is
+ * issue #246 item 7 (out of scope here); until then, this lets them register
+ * a policy for a session they didn't create so `resumeHardenedSession` still
+ * has something non-partial to derive a resume config from.
+ */
+export function registerSessionPolicy(sessionId: string, policy: SessionPolicy): void {
+  policyBySessionId.set(sessionId, policy);
+}
+
+/**
+ * Resumes a session under its stored policy. Per issue #246's requirement
+ * that a resume path never accept partial/caller-supplied config, this
+ * takes no config argument at all -- the full `SessionConfig` is always
+ * re-derived from whatever policy is on file for `sessionId` via
+ * `deriveSessionConfig`, the same derivation `createHardenedSession` uses.
+ *
+ * This is what fixes the two regressions issue #246 was opened over:
+ * `runForcedToolTurnUntilTimeout`'s nudge-retry resume no longer has a code
+ * path where it can drop `onPermissionRequest`/`autoApproveAll`, and
+ * `runForcedToolTurn`'s stall-retry resume no longer has one where it can
+ * drop `availableTools` -- both are always present because
+ * `deriveSessionConfig` always sets them, unconditionally.
+ *
+ * Throws if no policy is on file for `sessionId` (e.g. it was never created
+ * via `createHardenedSession`/`registerSessionPolicy`, or its policy was
+ * already evicted via `deleteHardenedSessionPolicy`) rather than silently
+ * falling back to the SDK's own resume defaults -- that fallback is exactly
+ * the failure mode this module exists to close off.
+ *
+ * `resumeSession` may hand back a session under a different `sessionId`
+ * than the one passed in; the policy is re-keyed under whatever id the SDK
+ * settles on so a *subsequent* resume of the same logical session still
+ * finds it, and the stale entry under the old id is dropped so it doesn't
+ * linger unused.
+ */
+export async function resumeHardenedSession(
+  client: CopilotClient,
+  sessionId: string,
+  /**
+   * Non-policy-owned fields (e.g. `provider`) the caller still needs to pass
+   * through on resume, same shape `createHardenedSession` takes for the
+   * initial create. Never used to supply `availableTools`, `tools`,
+   * `systemMessage`, `autoApproveAll`, or `onPermissionRequest` -- those
+   * remain exclusively policy-derived; `HardenedSessionBaseConfig` excludes
+   * them at the type level.
+   */
+  baseConfig: HardenedSessionBaseConfig = {}
+): Promise<CopilotSession> {
+  const policy = getStoredPolicy(sessionId);
+  if (!policy) {
+    throw new Error(
+      `[hardenedSession] resumeHardenedSession: no policy registered for session ${sessionId}. ` +
+      `Sessions must be created via createHardenedSession or registered via registerSessionPolicy ` +
+      `before they can be resumed through this module.`
+    );
+  }
+  const session = await client.resumeSession(sessionId, {
+    ...baseConfig,
+    ...deriveSessionConfig(policy),
+  } as SessionConfig);
+  if (session.sessionId !== sessionId) {
+    policyBySessionId.delete(sessionId);
+  }
+  policyBySessionId.set(session.sessionId, policy);
+  return session;
+}

--- a/src/test/hardenedSession.test.ts
+++ b/src/test/hardenedSession.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createHardenedSession,
+  registerSessionPolicy,
+  resumeHardenedSession,
+  deleteHardenedSessionPolicy,
+  SessionPolicy,
+} from '../copilotSdk/hardenedSession';
+import { CopilotClient } from '../copilotSdk/boundary';
+
+function makeMockClient(resumedSessionId?: string) {
+  const createSession = vi.fn(async (config: any) => ({
+    sessionId: 'session-created',
+    config,
+  }));
+  const resumeSession = vi.fn(async (sessionId: string, config: any) => ({
+    sessionId: resumedSessionId ?? sessionId,
+    config,
+  }));
+  return { createSession, resumeSession } as unknown as CopilotClient;
+}
+
+const policy: SessionPolicy = {
+  availableTools: ['read_file', 'write_file'],
+  autoApprovedTools: ['read_file'],
+};
+
+describe('resumeHardenedSession', () => {
+  it('re-derives the full config (availableTools, autoApproveAll: false, onPermissionRequest) on every resume', async () => {
+    const client = makeMockClient();
+    registerSessionPolicy('session-1', policy);
+
+    await resumeHardenedSession(client, 'session-1');
+
+    expect(client.resumeSession).toHaveBeenCalledTimes(1);
+    const [sessionId, config] = (client.resumeSession as any).mock.calls[0];
+    expect(sessionId).toBe('session-1');
+    expect(config.availableTools).toEqual(policy.availableTools);
+    expect(config.autoApproveAll).toBe(false);
+    expect(typeof config.onPermissionRequest).toBe('function');
+  });
+
+  it('throws rather than falling back to SDK defaults when no policy is registered', async () => {
+    const client = makeMockClient();
+    await expect(resumeHardenedSession(client, 'never-registered')).rejects.toThrow(/no policy registered/);
+    expect(client.resumeSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects a tool not present in autoApprovedTools', async () => {
+    const client = makeMockClient();
+    registerSessionPolicy('session-2', policy);
+    await resumeHardenedSession(client, 'session-2');
+    const config = (client.resumeSession as any).mock.calls[0][1];
+
+    const result = await config.onPermissionRequest(
+      { kind: 'shell' },
+      { sessionId: 'session-2' }
+    );
+    expect(result.kind).toBe('reject');
+  });
+
+  it('approves a tool present in autoApprovedTools', async () => {
+    const client = makeMockClient();
+    registerSessionPolicy('session-3', policy);
+    await resumeHardenedSession(client, 'session-3');
+    const config = (client.resumeSession as any).mock.calls[0][1];
+
+    const result = await config.onPermissionRequest(
+      { kind: 'custom-tool', toolName: 'read_file' },
+      { sessionId: 'session-3' }
+    );
+    expect(result.kind).toBe('approve-once');
+  });
+
+  it('re-keys the stored policy under the id resumeSession returns, and drops the stale id', async () => {
+    const client = makeMockClient('session-1-b');
+    registerSessionPolicy('session-1', policy);
+
+    const first = await resumeHardenedSession(client, 'session-1');
+    expect(first.sessionId).toBe('session-1-b');
+
+    // A follow-up resume must use the *new* id -- the old one is no longer valid.
+    await expect(resumeHardenedSession(client, 'session-1')).rejects.toThrow(/no policy registered/);
+
+    await resumeHardenedSession(client, 'session-1-b');
+    expect(client.resumeSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes through non-policy base config (e.g. provider) without letting it override policy fields', async () => {
+    const client = makeMockClient();
+    registerSessionPolicy('session-4', policy);
+
+    await resumeHardenedSession(client, 'session-4', { provider: 'openrouter' } as any);
+
+    const config = (client.resumeSession as any).mock.calls[0][1];
+    expect(config.provider).toBe('openrouter');
+    expect(config.availableTools).toEqual(policy.availableTools);
+    expect(config.autoApproveAll).toBe(false);
+  });
+
+  it('createHardenedSession binds a policy that a later resume can use without re-supplying config', async () => {
+    const client = makeMockClient();
+    await createHardenedSession(client, {}, policy);
+
+    await resumeHardenedSession(client, 'session-created');
+    const config = (client.resumeSession as any).mock.calls[0][1];
+    expect(config.availableTools).toEqual(policy.availableTools);
+    expect(config.autoApproveAll).toBe(false);
+  });
+
+  it('deleteHardenedSessionPolicy makes a subsequent resume fail loudly', async () => {
+    const client = makeMockClient();
+    registerSessionPolicy('session-5', policy);
+    deleteHardenedSessionPolicy('session-5');
+
+    await expect(resumeHardenedSession(client, 'session-5')).rejects.toThrow(/no policy registered/);
+  });
+});

--- a/src/utils/toolCallEnforcement.ts
+++ b/src/utils/toolCallEnforcement.ts
@@ -1,4 +1,5 @@
-import { CopilotClient, CopilotSession, SdkProviderConfig as ProviderConfig, SessionConfig, MessageOptions } from '../copilotSdk/boundary';
+import { CopilotClient, CopilotSession, SdkProviderConfig as ProviderConfig, SessionConfig, MessageOptions, Tool } from '../copilotSdk/boundary';
+import { registerSessionPolicy, resumeHardenedSession, SessionPolicy } from '../copilotSdk/hardenedSession';
 
 /**
  * How much of the model's last assistant message to include when we give up
@@ -278,6 +279,20 @@ export interface ForcedToolTurnOptions<T> {
   maxRetries?: number;
   getResult: () => T | undefined;
   tools?: any[]; // CopilotSDK Tool array
+  /**
+   * SDK-level tool allowlist for the turn as a whole (as opposed to the
+   * narrower `targetTools` allowlist a nudge-retry resume switches to). Fed
+   * into the `SessionPolicy` registered for stall-retry resumes via
+   * `registerSessionPolicy`/`resumeHardenedSession` (issue #246) so a
+   * stall-retry resume restores the same toolset the turn started with,
+   * rather than silently regaining access to every built-in tool
+   * (`bash`/`view`/`grep`/`task`) the way a resume with no `availableTools`
+   * at all does. Defaults to `targetTools` (the tool(s) this turn is forcing)
+   * if omitted, which is the safest default but may be narrower than what
+   * the initial send actually had available -- callers with a broader
+   * toolset for the initial send should pass it explicitly.
+   */
+  availableTools?: string[];
   responseRequirements?: { toolCallExample?: string };
   /**
    * Called with every session this turn runs on -- the initial session, and
@@ -326,6 +341,26 @@ export interface ForcedToolTurnOptions<T> {
 }
 
 
+/**
+ * Builds the `SessionPolicy` registered before every resume in
+ * `runForcedToolTurn`/`runForcedToolTurnUntilTimeout`. Auto-approves every
+ * tool in `availableTools` -- matching these functions' pre-#246 behavior of
+ * relying on `CopilotClient`'s auto-approve-all resume default -- but scoped
+ * to the tools actually allowed for the turn, rather than truly all tools.
+ */
+function buildResumePolicy(
+  availableTools: readonly string[],
+  tools: any[] | undefined,
+  systemMessage: SessionConfig['systemMessage'] | undefined
+): SessionPolicy {
+  return {
+    availableTools,
+    tools: tools as readonly Tool[] | undefined,
+    systemMessage,
+    autoApprovedTools: availableTools,
+  };
+}
+
 export async function runForcedToolTurn<T>(
   session: CopilotSession,
   executionConfig: { provider?: unknown },
@@ -342,6 +377,16 @@ export async function runForcedToolTurn<T>(
   
   let toolCalled = false;
   const targetTools = Array.isArray(toolName) ? toolName : [toolName];
+  const turnAvailableTools = opts.availableTools ?? targetTools;
+  // Tracks the availableTools allowlist currently in effect, so a stall-retry
+  // that fires while we're mid-nudge stays scoped to the nudge's narrower
+  // targetTools policy rather than reverting to the turn's full toolset.
+  let currentAvailableTools = turnAvailableTools;
+  const resumeSystemMessage = opts.freshSessionConfig?.systemMessage;
+  registerSessionPolicy(
+    currentSessionId,
+    buildResumePolicy(currentAvailableTools, opts.tools, resumeSystemMessage)
+  );
   let tracker = trackLastAssistantMessage(currentSession);
   
   const setupToolListener = (s: CopilotSession) => {
@@ -373,7 +418,6 @@ export async function runForcedToolTurn<T>(
    */
   const sendWithStallRetry = async (
     promptOpts: { prompt: string; tool_choice?: unknown },
-    resumeConfig: { availableTools?: string[]; tools?: unknown; provider?: ProviderConfig; systemMessage?: SessionConfig['systemMessage'] },
   ): Promise<void> => {
     let stallAttempt = 0;
     let currentPromptOpts = promptOpts;
@@ -435,7 +479,15 @@ export async function runForcedToolTurn<T>(
               `[runForcedToolTurn] upstream stall detected (attempt ${stallAttempt}/${maxStallRetries}); ` +
               `attempting to resume the stalled session before falling back to a fresh one...`,
             );
-            currentSession = await opts.client.resumeSession(currentSessionId, resumeConfig as SessionConfig);
+            registerSessionPolicy(
+              currentSessionId,
+              buildResumePolicy(currentAvailableTools, opts.tools, resumeSystemMessage)
+            );
+            currentSession = await resumeHardenedSession(
+              opts.client,
+              currentSessionId,
+              executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}
+            );
             currentSessionId = currentSession.sessionId;
             opts.onSessionId?.(currentSessionId);
             resumeAttempted = true;
@@ -458,7 +510,15 @@ export async function runForcedToolTurn<T>(
             `[runForcedToolTurn] upstream stall detected (attempt ${stallAttempt}/${maxStallRetries}); ` +
             `resuming session and retrying the same prompt...`,
           );
-          currentSession = await opts.client.resumeSession(currentSessionId, resumeConfig as SessionConfig);
+          registerSessionPolicy(
+            currentSessionId,
+            buildResumePolicy(currentAvailableTools, opts.tools, resumeSystemMessage)
+          );
+          currentSession = await resumeHardenedSession(
+            opts.client,
+            currentSessionId,
+            executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}
+          );
           currentSessionId = currentSession.sessionId;
           opts.onSessionId?.(currentSessionId);
         }
@@ -470,7 +530,7 @@ export async function runForcedToolTurn<T>(
     }
   };
 
-  await sendWithStallRetry({ prompt: initialPrompt }, { tools: opts.tools, systemMessage: opts.freshSessionConfig?.systemMessage, ...(executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}) });
+  await sendWithStallRetry({ prompt: initialPrompt });
   
   let lastAssistantText = tracker.getText();
   tracker.unsubscribe();
@@ -493,14 +553,16 @@ export async function runForcedToolTurn<T>(
       ? `You did not call any of: ${toolNamesStr}. Your last message was:\n"""\n${truncate(lastAssistantText.trim(), LAST_MESSAGE_TRUNCATE_LENGTH)}\n"""\nYou must now call one of ${toolNamesStr} with your findings. Do not respond conversationally, do not ask clarifying questions, and do not call any other tool -- call one of ${toolNamesStr} now.${exampleBlock}`
       : `You ended your turn without calling any of: ${toolNamesStr}. You must now call one of ${toolNamesStr} with your findings. Do not respond conversationally and do not call any other tool -- call one of ${toolNamesStr} now.${exampleBlock}`;
       
-    const resumeConfig = {
-      availableTools: targetTools,
-      tools: opts.tools,
-      systemMessage: opts.freshSessionConfig?.systemMessage,
-      ...(executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}),
-    };
-    
-    currentSession = await opts.client.resumeSession(currentSessionId, resumeConfig);
+    currentAvailableTools = targetTools;
+    registerSessionPolicy(
+      currentSessionId,
+      buildResumePolicy(currentAvailableTools, opts.tools, resumeSystemMessage)
+    );
+    currentSession = await resumeHardenedSession(
+      opts.client,
+      currentSessionId,
+      executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}
+    );
     currentSessionId = currentSession.sessionId;
     opts.onSessionId?.(currentSessionId);
     
@@ -515,7 +577,7 @@ export async function runForcedToolTurn<T>(
       promptOpts.tool_choice = { type: 'function', function: { name: targetTools[0] } };
     }
     
-    await sendWithStallRetry(promptOpts, resumeConfig);
+    await sendWithStallRetry(promptOpts);
     
     lastAssistantText = tracker.getText() || lastAssistantText;
     tracker.unsubscribe();
@@ -621,6 +683,10 @@ export async function runForcedToolTurnUntilTimeout<T>(
 
   let toolCalled = false;
   const targetTools = Array.isArray(toolName) ? toolName : [toolName];
+  registerSessionPolicy(
+    currentSessionId,
+    buildResumePolicy(opts.availableTools ?? targetTools, opts.tools, opts.systemMessage)
+  );
   let tracker = trackLastAssistantMessage(currentSession);
   // Same usage-telemetry logging sendAndWaitWithAbort does (issue #158,
   // #180). runForcedToolTurnUntilTimeout replaced runForcedToolTurn (and its
@@ -731,14 +797,15 @@ export async function runForcedToolTurnUntilTimeout<T>(
       ? `You did not call any of: ${toolNamesStr}. Your last message was:\n"""\n${truncate(lastAssistantText.trim(), LAST_MESSAGE_TRUNCATE_LENGTH)}\n"""\nYou must now call one of ${toolNamesStr} with your findings. Do not respond conversationally, do not ask clarifying questions, and do not call any other tool -- call one of ${toolNamesStr} now.${exampleBlock}`
       : `You ended your turn without calling any of: ${toolNamesStr}. You must now call one of ${toolNamesStr} with your findings. Do not respond conversationally and do not call any other tool -- call one of ${toolNamesStr} now.${exampleBlock}`;
 
-    const resumeConfig = {
-      availableTools: targetTools,
-      tools: opts.tools,
-      systemMessage: opts.systemMessage,
-      ...(executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}),
-    };
-
-    currentSession = await opts.client.resumeSession(currentSessionId, resumeConfig);
+    registerSessionPolicy(
+      currentSessionId,
+      buildResumePolicy(targetTools, opts.tools, opts.systemMessage)
+    );
+    currentSession = await resumeHardenedSession(
+      opts.client,
+      currentSessionId,
+      executionConfig.provider ? { provider: executionConfig.provider as ProviderConfig } : {}
+    );
     currentSessionId = currentSession.sessionId;
     opts.onSessionId?.(currentSessionId);
 


### PR DESCRIPTION
- Add resumeHardenedSession/registerSessionPolicy to hardenedSession.ts, re-deriving the full session config from the stored policy on every resume instead of accepting partial/caller-supplied config.
- Fix runForcedToolTurnUntilTimeout's nudge-retry resume, which dropped onPermissionRequest/autoApproveAll on resumeSession.
- Fix runForcedToolTurn's stall-retry resume, which dropped availableTools entirely on resumeSession.
- Add unit tests covering resume policy derivation, rejection of disallowed tools, re-keying on session id change, and missing-policy failure.