### PR TITLE
Fix #246: Enforce disallowed-tool rejection

### DIFF
--- a/src/copilotSdk/hardenedSession.ts
+++ b/src/copilotSdk/hardenedSession.ts
@@ -79,12 +79,50 @@ function extractRequestedToolName(req: PermissionRequest): string {
 }
 
 /**
+ * Records rejected permission attempts per session, keyed by session id, so
+ * callers/tests can verify *what* was attempted and rejected -- not just
+ * that a rejection happened. Console output alone (the previous behavior)
+ * isn't queryable and disappears once the process log rotates; this is
+ * issue #246 item 3's "the attempted tool name is recorded" requirement.
+ */
+const rejectedAttemptsBySessionId = new Map<string, string[]>();
+
+/**
+ * Returns the tool names rejected so far for `sessionId`, in the order they
+ * were attempted. Returns an empty array (not undefined) for a session with
+ * no rejections on file, so callers don't need an existence check.
+ */
+export function getRejectedToolAttempts(sessionId: string): readonly string[] {
+  return rejectedAttemptsBySessionId.get(sessionId) ?? [];
+}
+
+/** Clears recorded rejection history for a session, e.g. alongside `deleteHardenedSessionPolicy` during cleanup. */
+export function clearRejectedToolAttempts(sessionId: string): void {
+  rejectedAttemptsBySessionId.delete(sessionId);
+}
+
+function recordRejectedAttempt(sessionId: string, toolName: string): void {
+  const existing = rejectedAttemptsBySessionId.get(sessionId);
+  if (existing) {
+    existing.push(toolName);
+  } else {
+    rejectedAttemptsBySessionId.set(sessionId, [toolName]);
+  }
+}
+
+/**
  * Builds the `onPermissionRequest` handler enforcing `autoApprovedTools`.
  * Anything not in that set is rejected (issue #246's "disallowed-tool
  * rejection" requirement) rather than falling through to
  * `CopilotClient`'s own `autoApproveAll` default of `true`
  * (src/copilotSdk/boundary.ts) -- this handler is only ever installed
  * alongside `autoApproveAll: false`, so that default never applies here.
+ *
+ * Built-in tools like `bash`/`view`/`grep`/`task` (subagent) are rejected
+ * by this same path whenever they're absent from `autoApprovedTools` --
+ * there is no separate allowlist for them, so they stay unavailable by
+ * default unless a policy explicitly opts them in (issue #246's
+ * state-driven requirement).
  */
 function derivePermissionHandler(
   policy: SessionPolicy
@@ -95,6 +133,7 @@ function derivePermissionHandler(
     if (allowed.has(requestedTool)) {
       return { kind: 'approve-once' };
     }
+    recordRejectedAttempt(invocation.sessionId, requestedTool);
     console.warn(
       `[hardenedSession] session ${invocation.sessionId}: rejected permission request for disallowed ` +
       `tool '${requestedTool}' (allowed: ${[...allowed].join(', ') || '(none)'})`
@@ -146,6 +185,7 @@ export function getStoredPolicy(sessionId: string): SessionPolicy | undefined {
  */
 export function deleteHardenedSessionPolicy(sessionId: string): void {
   policyBySessionId.delete(sessionId);
+  clearRejectedToolAttempts(sessionId);
 }
 
 /**

--- a/src/test/hardenedSession.test.ts
+++ b/src/test/hardenedSession.test.ts
@@ -4,6 +4,8 @@ import {
   registerSessionPolicy,
   resumeHardenedSession,
   deleteHardenedSessionPolicy,
+  getRejectedToolAttempts,
+  clearRejectedToolAttempts,
   SessionPolicy,
 } from '../copilotSdk/hardenedSession';
 import { CopilotClient } from '../copilotSdk/boundary';
@@ -127,5 +129,108 @@ describe('resumeHardenedSession', () => {
     deleteHardenedSessionPolicy('session-6');
 
     await expect(resumeHardenedSession(client, 'session-6')).rejects.toThrow(/no policy registered/);
+  });
+});
+
+describe('disallowed-tool rejection (issue #246 item 3)', () => {
+  // A policy that doesn't opt any built-in into autoApprovedTools -- the
+  // default posture every session should have unless a policy explicitly
+  // widens it.
+  const noBuiltInsPolicy: SessionPolicy = {
+    availableTools: ['read_file'],
+    autoApprovedTools: ['read_file'],
+  };
+
+  it.each([
+    { name: 'bash', req: { kind: 'shell' } },
+    { name: 'view', req: { kind: 'read' } },
+    { name: 'grep', req: { kind: 'custom-tool', toolName: 'grep' } },
+    { name: 'task', req: { kind: 'custom-tool', toolName: 'task' } },
+  ])('rejects a resumed session\'s request for the disallowed "$name" tool', async ({ req }) => {
+    const client = makeMockClient();
+    const sessionId = `builtin-reject-${req.kind}-${'toolName' in req ? req.toolName : 'k'}`;
+    registerSessionPolicy(sessionId, noBuiltInsPolicy);
+    await resumeHardenedSession(client, sessionId);
+    const config = (client.resumeSession as any).mock.calls[0][1];
+
+    const result = await config.onPermissionRequest(req, { sessionId });
+
+    expect(result.kind).toBe('reject');
+  });
+
+  it('leaves bash/view/grep/task unavailable by default when a policy does not explicitly include them', async () => {
+    const client = makeMockClient();
+    registerSessionPolicy('session-defaults', noBuiltInsPolicy);
+    await resumeHardenedSession(client, 'session-defaults');
+    const config = (client.resumeSession as any).mock.calls[0][1];
+
+    for (const req of [
+      { kind: 'shell' },
+      { kind: 'read' },
+      { kind: 'custom-tool', toolName: 'grep' },
+      { kind: 'custom-tool', toolName: 'task' },
+    ]) {
+      const result = await config.onPermissionRequest(req, { sessionId: 'session-defaults' });
+      expect(result.kind).toBe('reject');
+    }
+  });
+
+  it('approves a built-in that a policy explicitly opts into autoApprovedTools', async () => {
+    const client = makeMockClient();
+    const policyWithShell: SessionPolicy = {
+      availableTools: ['read_file'],
+      autoApprovedTools: ['shell'],
+    };
+    registerSessionPolicy('session-explicit-shell', policyWithShell);
+    await resumeHardenedSession(client, 'session-explicit-shell');
+    const config = (client.resumeSession as any).mock.calls[0][1];
+
+    const result = await config.onPermissionRequest({ kind: 'shell' }, { sessionId: 'session-explicit-shell' });
+
+    expect(result.kind).toBe('approve-once');
+  });
+
+  it('records the attempted tool name for each rejection, in order', async () => {
+    const client = makeMockClient();
+    registerSessionPolicy('session-record', noBuiltInsPolicy);
+    await resumeHardenedSession(client, 'session-record');
+    const config = (client.resumeSession as any).mock.calls[0][1];
+
+    await config.onPermissionRequest({ kind: 'shell' }, { sessionId: 'session-record' });
+    await config.onPermissionRequest({ kind: 'custom-tool', toolName: 'task' }, { sessionId: 'session-record' });
+    // An approved request should not show up in the rejection record.
+    await config.onPermissionRequest({ kind: 'custom-tool', toolName: 'read_file' }, { sessionId: 'session-record' });
+
+    expect(getRejectedToolAttempts('session-record')).toEqual(['shell', 'task']);
+  });
+
+  it('returns an empty array for a session with no rejections on file', () => {
+    expect(getRejectedToolAttempts('never-rejected-anything')).toEqual([]);
+  });
+
+  it('clearRejectedToolAttempts resets the record for a session', async () => {
+    const client = makeMockClient();
+    registerSessionPolicy('session-clear', noBuiltInsPolicy);
+    await resumeHardenedSession(client, 'session-clear');
+    const config = (client.resumeSession as any).mock.calls[0][1];
+    await config.onPermissionRequest({ kind: 'shell' }, { sessionId: 'session-clear' });
+    expect(getRejectedToolAttempts('session-clear')).toEqual(['shell']);
+
+    clearRejectedToolAttempts('session-clear');
+
+    expect(getRejectedToolAttempts('session-clear')).toEqual([]);
+  });
+
+  it('deleteHardenedSessionPolicy also clears the recorded rejection history', async () => {
+    const client = makeMockClient();
+    registerSessionPolicy('session-delete-clears', noBuiltInsPolicy);
+    await resumeHardenedSession(client, 'session-delete-clears');
+    const config = (client.resumeSession as any).mock.calls[0][1];
+    await config.onPermissionRequest({ kind: 'shell' }, { sessionId: 'session-delete-clears' });
+    expect(getRejectedToolAttempts('session-delete-clears')).toEqual(['shell']);
+
+    deleteHardenedSessionPolicy('session-delete-clears');
+
+    expect(getRejectedToolAttempts('session-delete-clears')).toEqual([]);
   });
 });


### PR DESCRIPTION
- Record each rejected onPermissionRequest attempt's tool name (per session, in order) via getRejectedToolAttempts/clearRejectedToolAttempts, instead of only console.warn-ing it -- makes the 'attempted tool name is recorded' requirement queryable/testable, not just logged.
- Wire clearRejectedToolAttempts into deleteHardenedSessionPolicy so rejection history doesn't outlive the policy it belongs to.
- Add regression tests asserting bash/view/grep/task are rejected by default on a resumed session unless explicitly present in autoApprovedTools, plus a test that an explicit opt-in (e.g. shell) is approved.