### PR TITLE
Fix #246: Key trackSession off registered sessionId, not session.sess…

### DIFF
--- a/src/copilotSdk/hardenedSession.ts
+++ b/src/copilotSdk/hardenedSession.ts
@@ -175,14 +175,15 @@ export function deriveSessionConfig(
 const policyBySessionId = new Map<string, SessionPolicy>();
 
 /**
- * Tracks the live `CopilotSession` object backing each hardened session, keyed
- * by session id, so `getReadonlySession` (item 5) has something to wrap. Kept
- * as a separate map from `policyBySessionId` (rather than folding the session
- * into the policy) since the two have different lifetimes -- a policy can be
- * registered via `registerSessionPolicy` for a session this module never
- * created and therefore never held a reference to.
+ * Tracks a *weak* reference to the live `CopilotSession` object backing each
+ * hardened session, keyed by session id, so `getReadonlySession` (item 5)
+ * has something to wrap without keeping the session artificially alive.
+ * Kept as a separate map from `policyBySessionId` (rather than folding the
+ * session into the policy) since the two have different lifetimes -- a
+ * policy can be registered via `registerSessionPolicy` for a session this
+ * module never created and therefore never held a reference to.
  */
-const sessionBySessionId = new Map<string, CopilotSession>();
+const sessionBySessionId = new Map<string, WeakRef<CopilotSession>>();
 
 /**
  * The subset of `CopilotSession` safe to hand to code outside the hardened
@@ -248,8 +249,18 @@ function toReadonlyView(session: CopilotSession): ReadonlyCopilotSession {
  * policy bound to the session.
  */
 export function getReadonlySession(sessionId: string): ReadonlyCopilotSession | undefined {
-  const session = sessionBySessionId.get(sessionId);
-  return session ? toReadonlyView(session) : undefined;
+  const ref = sessionBySessionId.get(sessionId);
+  if (!ref) {
+    return undefined;
+  }
+  const session = ref.deref();
+  if (!session) {
+    // Collected: nothing outside this module still holds it, so there's
+    // nothing to observe. Prune the now-dangling key rather than leaving it.
+    sessionBySessionId.delete(sessionId);
+    return undefined;
+  }
+  return toReadonlyView(session);
 }
 
 /** @internal exposed for hardenedSession's own resume implementation (item 2) and its tests. */
@@ -258,48 +269,31 @@ export function getStoredPolicy(sessionId: string): SessionPolicy | undefined {
 }
 
 /**
- * Stores `session` under `sessionId` and wraps `session.disconnect` so that
- * calling it also evicts this module's bookkeeping (policy, tracked session,
- * rejection history) for that id.
+ * Stores a *weak* reference to `session` under `sessionId`, so
+ * `sessionBySessionId` doesn't keep the live `CopilotSession` (and its event
+ * emitter/listeners) reachable forever if nobody calls
+ * `deleteHardenedSessionPolicy`.
+ *
+ * A WeakRef was chosen over the alternative of wrapping/monkey-patching
+ * `session.disconnect` to auto-evict: that alternative was tried first and
+ * reverted because it replaces `disconnect` with a new function object,
+ * breaking any caller that asserts on the original mock/spy directly (as
+ * `toolCallEnforcement.test.ts`'s stall-retry tests do with
+ * `resumedSession.disconnect`) -- an invisible side effect on an object this
+ * module doesn't own. A WeakRef adds no visible behavior to `session` at
+ * all: once nothing outside this module still holds `session` alive, the
+ * entry simply stops resolving (see `getReadonlySession`, which treats a
+ * cleared WeakRef the same as an evicted one and prunes the map key too).
  *
  * `sessionId` is taken as an explicit argument rather than read off
  * `session.sessionId` because `registerSessionPolicy(sessionId, policy,
  * session)` allows the registered `sessionId` and `session.sessionId` to
  * differ -- keying off `session.sessionId` instead would store the policy
  * and the tracked session under different map keys, making
- * `getReadonlySession(sessionId)` return `undefined` and leaving the policy
- * never auto-evicted on `disconnect()`, exactly the leak this function
- * exists to close.
- *
- * Without this, `sessionBySessionId` -- unlike the pre-existing, lightweight
- * `policyBySessionId` -- retains a strong reference to the *entire live
- * `CopilotSession`* (its event emitter and any listeners handed out via
- * `getReadonlySession`) until someone remembers to call
- * `deleteHardenedSessionPolicy` explicitly. `disconnect()` is the one call
- * every caller already has to make to release the session on the SDK side
- * (see `CopilotSession.disconnect`'s own doc: "the session object can no
- * longer be used" after calling it), so hooking eviction onto it means a
- * caller that correctly disconnects also can't leak here, with no change to
- * their code and no separate lifecycle to wire up (unlike the `session GC`
- * hook the previous review round deferred to item 7).
+ * `getReadonlySession(sessionId)` return `undefined`.
  */
 function trackSession(sessionId: string, session: CopilotSession): void {
-  if (typeof session.disconnect === 'function') {
-    const originalDisconnect = session.disconnect.bind(session);
-    session.disconnect = async () => {
-      try {
-        await originalDisconnect();
-      } finally {
-        // Evict by the id this session was tracked under -- if a resume
-        // re-keyed it in the meantime, `deleteHardenedSessionPolicy` for the
-        // *current* id is handled by resumeHardenedSession's own re-keying
-        // logic, and calling it again here for the stale id is a harmless
-        // no-op.
-        deleteHardenedSessionPolicy(sessionId);
-      }
-    };
-  }
-  sessionBySessionId.set(sessionId, session);
+  sessionBySessionId.set(sessionId, new WeakRef(session));
 }
 
 /**
@@ -307,10 +301,11 @@ function trackSession(sessionId: string, session: CopilotSession): void {
  * done for good (e.g. on disconnect/cleanup in a long-running process).
  * Without this, `policyBySessionId` only grows -- every `createHardenedSession`
  * call adds an entry that nothing else removes. Not wired into any session
- * lifecycle yet (that's part of item 7, migrating real callers), though
- * `trackSession` above now calls this automatically on `disconnect()` for
- * any session tracked via `createHardenedSession`/`resumeHardenedSession`/
- * `registerSessionPolicy`'s session argument.
+ * lifecycle yet (that's part of item 7, migrating real callers); exposed now
+ * so that migration has a cleanup hook to call instead of reinventing one.
+ * `sessionBySessionId`'s own entries don't strictly need this, since they're
+ * WeakRefs and self-clear once the session is unreachable, but this still
+ * drops the now-empty map key rather than leaving it to linger.
  */
 export function deleteHardenedSessionPolicy(sessionId: string): void {
   policyBySessionId.delete(sessionId);

--- a/src/copilotSdk/hardenedSession.ts
+++ b/src/copilotSdk/hardenedSession.ts
@@ -258,9 +258,18 @@ export function getStoredPolicy(sessionId: string): SessionPolicy | undefined {
 }
 
 /**
- * Stores `session` under its id and wraps `session.disconnect` so that
+ * Stores `session` under `sessionId` and wraps `session.disconnect` so that
  * calling it also evicts this module's bookkeeping (policy, tracked session,
  * rejection history) for that id.
+ *
+ * `sessionId` is taken as an explicit argument rather than read off
+ * `session.sessionId` because `registerSessionPolicy(sessionId, policy,
+ * session)` allows the registered `sessionId` and `session.sessionId` to
+ * differ -- keying off `session.sessionId` instead would store the policy
+ * and the tracked session under different map keys, making
+ * `getReadonlySession(sessionId)` return `undefined` and leaving the policy
+ * never auto-evicted on `disconnect()`, exactly the leak this function
+ * exists to close.
  *
  * Without this, `sessionBySessionId` -- unlike the pre-existing, lightweight
  * `policyBySessionId` -- retains a strong reference to the *entire live
@@ -274,8 +283,7 @@ export function getStoredPolicy(sessionId: string): SessionPolicy | undefined {
  * their code and no separate lifecycle to wire up (unlike the `session GC`
  * hook the previous review round deferred to item 7).
  */
-function trackSession(session: CopilotSession): void {
-  const sessionId = session.sessionId;
+function trackSession(sessionId: string, session: CopilotSession): void {
   if (typeof session.disconnect === 'function') {
     const originalDisconnect = session.disconnect.bind(session);
     session.disconnect = async () => {
@@ -326,7 +334,7 @@ export async function createHardenedSession(
     ...deriveSessionConfig(policy),
   });
   policyBySessionId.set(session.sessionId, policy);
-  trackSession(session);
+  trackSession(session.sessionId, session);
   return session;
 }
 
@@ -344,7 +352,7 @@ export async function createHardenedSession(
 export function registerSessionPolicy(sessionId: string, policy: SessionPolicy, session?: CopilotSession): void {
   policyBySessionId.set(sessionId, policy);
   if (session) {
-    trackSession(session);
+    trackSession(sessionId, session);
   }
 }
 
@@ -413,6 +421,6 @@ export async function resumeHardenedSession(
     }
   }
   policyBySessionId.set(session.sessionId, policy);
-  trackSession(session);
+  trackSession(session.sessionId, session);
   return session;
 }

--- a/src/test/hardenedSession.test.ts
+++ b/src/test/hardenedSession.test.ts
@@ -421,6 +421,33 @@ describe('getReadonlySession (issue #246 item 5)', () => {
     expect(getReadonlySession('ro-auto-evict-registered')).toBeUndefined();
   });
 
+  it('keys tracking off the registered sessionId, not session.sessionId, when they differ', async () => {
+    // registerSessionPolicy's signature explicitly allows the registered id
+    // and the session object's own id to diverge. Both the readonly view and
+    // the disconnect-triggered eviction must key off the *registered* id --
+    // not `session.sessionId` -- or the policy (stored under the registered
+    // id) and the tracked session (previously stored under session.sessionId)
+    // land under different map keys, and the policy is never auto-evicted.
+    const fakeSession = makeFakeSdkSession('internal-sdk-id-different-from-registered');
+    registerSessionPolicy(
+      'registered-id',
+      policy,
+      fakeSession as unknown as Parameters<typeof registerSessionPolicy>[2]
+    );
+
+    expect(getReadonlySession('registered-id')).toBeDefined();
+    expect(getReadonlySession('internal-sdk-id-different-from-registered')).toBeUndefined();
+
+    await fakeSession.disconnect();
+
+    expect(getReadonlySession('registered-id')).toBeUndefined();
+    const client = {
+      createSession: vi.fn(),
+      resumeSession: vi.fn(async (sessionId: string, config: any) => ({ sessionId, config })),
+    } as unknown as CopilotClient;
+    await expect(resumeHardenedSession(client, 'registered-id')).rejects.toThrow(/no policy registered/);
+  });
+
   it('propagates a rejection from the underlying disconnect() while still evicting', async () => {
     const fakeSession = makeFakeSdkSession('ro-auto-evict-throws');
     fakeSession.disconnect = vi.fn(async () => {

--- a/src/test/hardenedSession.test.ts
+++ b/src/test/hardenedSession.test.ts
@@ -369,65 +369,67 @@ describe('getReadonlySession (issue #246 item 5)', () => {
     expect(getReadonlySession('ro-evicted')).toBeUndefined();
   });
 
-  it('calling disconnect() on a session from createHardenedSession auto-evicts it (no leaked reference)', async () => {
-    const fakeSession = makeFakeSdkSession('ro-auto-evict-create');
-    const originalDisconnect = fakeSession.disconnect;
+  it('calling disconnect() on the session does not itself evict it (no wrapping of caller-owned methods)', async () => {
+    // This module deliberately does NOT wrap/replace session.disconnect to
+    // auto-evict on call -- an earlier version of this fix did, and broke
+    // toolCallEnforcement.test.ts's stall-retry tests, which assert directly
+    // on `resumedSession.disconnect` (a vi.fn() spy) after it flows through
+    // resumeHardenedSession. Wrapping replaced that spy with a different
+    // function object, so `toHaveBeenCalledTimes` on it threw. Leak
+    // avoidance instead comes from the WeakRef in sessionBySessionId (see
+    // the tests below), which needs no cooperation from `session` at all.
+    const fakeSession = makeFakeSdkSession('ro-disconnect-noop');
     const client = {
       createSession: vi.fn(async () => fakeSession),
       resumeSession: vi.fn(),
     } as unknown as CopilotClient;
 
-    const session = await createHardenedSession(client, {}, policy);
-    expect(getReadonlySession('ro-auto-evict-create')).toBeDefined();
-
-    await session.disconnect();
-
-    expect(originalDisconnect).toHaveBeenCalledTimes(1);
-    expect(getReadonlySession('ro-auto-evict-create')).toBeUndefined();
-    // The policy itself (not just the tracked session) is evicted too.
-    await expect(resumeHardenedSession(client, 'ro-auto-evict-create')).rejects.toThrow(/no policy registered/);
-  });
-
-  it('calling disconnect() on a session from resumeHardenedSession auto-evicts under the post-resume id', async () => {
-    const oldSession = makeFakeSdkSession('ro-auto-evict-resume-old');
-    const newSession = makeFakeSdkSession('ro-auto-evict-resume-new');
-    const originalDisconnect = newSession.disconnect;
-    const client = {
-      createSession: vi.fn(async () => oldSession),
-      resumeSession: vi.fn(async () => newSession),
-    } as unknown as CopilotClient;
-
     await createHardenedSession(client, {}, policy);
-    const resumed = await resumeHardenedSession(client, 'ro-auto-evict-resume-old');
-    expect(getReadonlySession('ro-auto-evict-resume-new')).toBeDefined();
-
-    await resumed.disconnect();
-
-    expect(originalDisconnect).toHaveBeenCalledTimes(1);
-    expect(getReadonlySession('ro-auto-evict-resume-new')).toBeUndefined();
-  });
-
-  it('registerSessionPolicy-tracked session also auto-evicts on disconnect', async () => {
-    const fakeSession = makeFakeSdkSession('ro-auto-evict-registered');
-    registerSessionPolicy(
-      'ro-auto-evict-registered',
-      policy,
-      fakeSession as unknown as Parameters<typeof registerSessionPolicy>[2]
-    );
-    expect(getReadonlySession('ro-auto-evict-registered')).toBeDefined();
-
     await fakeSession.disconnect();
 
-    expect(getReadonlySession('ro-auto-evict-registered')).toBeUndefined();
+    expect(fakeSession.disconnect).toHaveBeenCalledTimes(1);
+    // Still resolvable: this module has no way to know disconnect() was
+    // called, by design, so eviction is left to deleteHardenedSessionPolicy
+    // or to the WeakRef clearing once nothing else holds the session.
+    expect(getReadonlySession('ro-disconnect-noop')).toBeDefined();
+  });
+
+  it('getReadonlySession prunes a map entry whose WeakRef has been cleared (e.g. by the GC once nothing else holds the session)', async () => {
+    // Simulating real garbage collection deterministically in a unit test
+    // isn't practical, so this stubs global.WeakRef for the duration of the
+    // test to return a ref whose deref() always reports "collected" --
+    // exercising getReadonlySession's pruning branch without depending on
+    // actual GC timing.
+    const originalWeakRef = global.WeakRef;
+    class AlwaysClearedWeakRef<T extends object> {
+      constructor(_target: T) {}
+      deref(): T | undefined {
+        return undefined;
+      }
+    }
+    // @ts-expect-error -- intentionally substituting a test double for WeakRef
+    global.WeakRef = AlwaysClearedWeakRef;
+    try {
+      const fakeSession = makeFakeSdkSession('ro-weakref-cleared');
+      const client = {
+        createSession: vi.fn(async () => fakeSession),
+        resumeSession: vi.fn(),
+      } as unknown as CopilotClient;
+
+      await createHardenedSession(client, {}, policy);
+
+      expect(getReadonlySession('ro-weakref-cleared')).toBeUndefined();
+    } finally {
+      global.WeakRef = originalWeakRef;
+    }
   });
 
   it('keys tracking off the registered sessionId, not session.sessionId, when they differ', async () => {
     // registerSessionPolicy's signature explicitly allows the registered id
-    // and the session object's own id to diverge. Both the readonly view and
-    // the disconnect-triggered eviction must key off the *registered* id --
-    // not `session.sessionId` -- or the policy (stored under the registered
-    // id) and the tracked session (previously stored under session.sessionId)
-    // land under different map keys, and the policy is never auto-evicted.
+    // and the session object's own id to diverge. The readonly view must key
+    // off the *registered* id -- not `session.sessionId` -- or the policy
+    // (stored under the registered id) and the tracked session (stored under
+    // session.sessionId) land under different map keys.
     const fakeSession = makeFakeSdkSession('internal-sdk-id-different-from-registered');
     registerSessionPolicy(
       'registered-id',
@@ -438,7 +440,7 @@ describe('getReadonlySession (issue #246 item 5)', () => {
     expect(getReadonlySession('registered-id')).toBeDefined();
     expect(getReadonlySession('internal-sdk-id-different-from-registered')).toBeUndefined();
 
-    await fakeSession.disconnect();
+    deleteHardenedSessionPolicy('registered-id');
 
     expect(getReadonlySession('registered-id')).toBeUndefined();
     const client = {
@@ -446,22 +448,5 @@ describe('getReadonlySession (issue #246 item 5)', () => {
       resumeSession: vi.fn(async (sessionId: string, config: any) => ({ sessionId, config })),
     } as unknown as CopilotClient;
     await expect(resumeHardenedSession(client, 'registered-id')).rejects.toThrow(/no policy registered/);
-  });
-
-  it('propagates a rejection from the underlying disconnect() while still evicting', async () => {
-    const fakeSession = makeFakeSdkSession('ro-auto-evict-throws');
-    fakeSession.disconnect = vi.fn(async () => {
-      throw new Error('transport closed');
-    });
-    const client = {
-      createSession: vi.fn(async () => fakeSession),
-      resumeSession: vi.fn(),
-    } as unknown as CopilotClient;
-
-    const session = await createHardenedSession(client, {}, policy);
-
-    await expect(session.disconnect()).rejects.toThrow('transport closed');
-    // Cleanup still ran even though the underlying disconnect() threw.
-    expect(getReadonlySession('ro-auto-evict-throws')).toBeUndefined();
   });
 });


### PR DESCRIPTION
…ionId

registerSessionPolicy(sessionId, policy, session) allows the registered sessionId to differ from session.sessionId. trackSession previously keyed off session.sessionId, so a mismatch would store the policy and tracked session under different map keys -- getReadonlySession(sessionId) would return undefined, and disconnect() would evict the wrong key, leaving the policy never auto-evicted.