### PR TITLE
Fix #266: extend hardenedSession lint rule to scripts/ and migrate ru…

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,7 @@ export default [
     // calls are the base-class delegation the override wraps, not a bypass.
     // Test files are exempt where they intentionally exercise the raw SDK
     // client itself (e.g. proxy/integration tests), not the hardened wrapper.
-    files: ["src/**/*.ts", "src/**/*.tsx"],
+    files: ["src/**/*.ts", "src/**/*.tsx", "scripts/**/*.ts"],
     ignores: [
       "src/copilotSdk/boundary.ts",
       "src/copilotSdk/hardenedSession.ts",

--- a/scripts/run-issue-task.ts
+++ b/scripts/run-issue-task.ts
@@ -126,7 +126,7 @@ async function main() {
       content: systemPrompt,
     };
     const policy: SessionPolicy = {
-      availableTools: new ToolSet().addCustom(RUN_GH_COMMAND_TOOL_NAME) as unknown as readonly string[],
+      availableTools: new ToolSet().addCustom(RUN_GH_COMMAND_TOOL_NAME).toArray(),
       tools: [runGhCommandTool] as unknown as SessionPolicy['tools'],
       systemMessage,
       autoApprovedTools: [RUN_GH_COMMAND_TOOL_NAME],

--- a/scripts/run-issue-task.ts
+++ b/scripts/run-issue-task.ts
@@ -12,6 +12,7 @@ import { app, setActiveOpenRouterSessionId } from '../src/serverRuntime';
 import { getReviewerExecutionConfig } from '../src/utils/auditorHelper';
 import { runForcedToolTurnUntilTimeout } from '../src/utils/toolCallEnforcement';
 import { CopilotClient, type SessionConfig, type SdkProviderConfig, ToolSet } from '../src/copilotSdk/boundary';
+import { createHardenedSession, type SessionPolicy } from '../src/copilotSdk/hardenedSession';
 import {
   createRunGhCommandTool,
   ALLOWED_GH_COMMANDS,
@@ -120,35 +121,28 @@ async function main() {
     await client.start();
 
     console.log('[run-issue-task] creating session...');
-    const sessionConfig: SessionConfig & { autoApproveAll?: boolean } = {
+    const systemMessage: SessionConfig['systemMessage'] = {
+      mode: 'replace',
+      content: systemPrompt,
+    };
+    const policy: SessionPolicy = {
+      availableTools: new ToolSet().addCustom(RUN_GH_COMMAND_TOOL_NAME) as unknown as readonly string[],
+      tools: [runGhCommandTool] as unknown as SessionPolicy['tools'],
+      systemMessage,
+      autoApprovedTools: [RUN_GH_COMMAND_TOOL_NAME],
+    };
+    // sessionConfig retains the non-policy fields (plus tools/systemMessage, which
+    // runForcedToolTurnUntilTimeout below also needs) that createHardenedSession
+    // doesn't own; the policy-owned fields (availableTools/autoApproveAll/
+    // onPermissionRequest) are derived from `policy` above instead of set here.
+    const sessionConfig = {
       model: executionConfig.model,
       ...(executionConfig.provider ? { provider: executionConfig.provider as SdkProviderConfig } : {}),
-      systemMessage: {
-        mode: 'replace',
-        content: systemPrompt,
-      },
+      systemMessage,
       tools: [runGhCommandTool],
-      availableTools: new ToolSet().addCustom(RUN_GH_COMMAND_TOOL_NAME),
-      autoApproveAll: false,
-      onPermissionRequest: async (req) => {
-        let requestedTool: string | undefined;
-        if ('toolName' in req) {
-          requestedTool = req.toolName as string;
-        } else if ('name' in req) {
-          requestedTool = req.name as string;
-        } else if ('toolCalls' in req && Array.isArray(req.toolCalls)) {
-          const firstCall = req.toolCalls[0] as { function?: { name?: string } } | undefined;
-          requestedTool = firstCall?.function?.name;
-        }
-
-        if (requestedTool === RUN_GH_COMMAND_TOOL_NAME) {
-          return { kind: 'approve-once' };
-        }
-        return { kind: 'reject', reason: `Tool ${requestedTool || 'unknown'} is not permitted.` };
-      },
       streaming: false,
     };
-    const session = await client.createSession(sessionConfig);
+    const session = await createHardenedSession(client, sessionConfig, policy);
 
     sessionId = session.sessionId;
     console.log(`[run-issue-task] session created: ${sessionId}`);


### PR DESCRIPTION
…… (#267)




**Title:** hardenedSession lint rule does not cover `scripts/` (`run-issue-task.ts` createSession call unflagged)

## Background

Issue #246 introduced `src/copilotSdk/hardenedSession.ts` as the sole sanctioned entry point for `CopilotClient.createSession`/`resumeSession`, plus an eslint `no-restricted-syntax` rule to catch any remaining direct calls (per #246's requirement that any call outside the wrapper "shall be flagged by lint rule or code review checklist as a violation").

That rule's `files` glob in `eslint.config.js` is scoped to `src/**/*.ts` / `src/**/*.tsx` — it doesn't cover `scripts/`.

`scripts/run-issue-task.ts` (one of the two files #246 explicitly named under "Related follow-ups... Refactor `run-issue-task.ts`, `review-pr.ts`... to use the new wrapper") calls `client.createSession(sessionConfig)` directly at line 151, with:
- no migration to `createHardenedSession`, and
- no lint coverage flagging it — unlike every unmigrated call site under `src/`, which all carry a documented `eslint-disable-next-line` referencing #246 item 7.

So this call site is currently invisible to the enforcement mechanism #246 built: neither migrated nor flagged, which the issue's requirements say should be impossible.

`scripts/review-pr.ts` was checked and does not call `createSession`/`resumeSession` directly (only references it in a comment), so no action needed there.

## Requirements (EARS)

- The system shall extend the `no-restricted-syntax` rule from #246 to cover `scripts/**/*.ts`, not just `src/**/*.ts`.
- Where a call site under `scripts/` cannot yet be migrated to `createHardenedSession`/`resumeHardenedSession`, the system shall require a documented `eslint-disable-next-line` comment referencing this issue, consistent with existing `src/` call sites.
- The system shall either migrate `scripts/run-issue-task.ts`'s `client.createSession` call to `createHardenedSession`, or add the documented disable comment, so `npm run lint` surfaces or resolves this call site.

## Suggested approach

1. Widen the eslint config block for `no-restricted-syntax` to include `scripts/**/*.ts` (same `ignores` conventions as `src/`).
2. Run `npm run lint` and confirm `scripts/run-issue-task.ts:151` is flagged.
3. Either migrate that call site to `createHardenedSession` (preferred, consistent with #246 item 7), or add a documented disable comment matching the existing convention.
4. Re-check other `scripts/*.ts` files for direct `createSession`/`resumeSession` calls now that the rule applies there.

## Out of scope

- Broader migration of `scripts/run-issue-task.ts` beyond the single flagged call site (tracked under #246 item 7 if not resolved here).

