### PR TITLE
Fix #273: Add workflow-hotswap file for the codebase auditor script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "diagnose:gates": "tsx scripts/diagnose-gates.ts",
     "review:pr": "tsx scripts/review-pr.ts",
     "agent:issue": "tsx scripts/run-issue-task.ts",
+    "agent:audit": "tsx scripts/audit-codebase.ts",
     "import:repo": "tsx scripts/import-repo.ts",
     "diff:repo": "tsx scripts/remote-diff.ts",
     "test": "vitest run",

--- a/workflow-hotswap/audit-codebase.yml
+++ b/workflow-hotswap/audit-codebase.yml
@@ -1,0 +1,61 @@
+name: Audit Codebase Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      spec_paths:
+        description: 'Optional comma-separated spec doc path(s) to audit against (e.g. roadmap-spec.md,scripts/review-agent-spec.md). Leave blank to auto-discover *-spec.md files.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit-codebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard against running on the upstream repo
+        env:
+          IS_FORK_REPO: ${{ vars.IS_FORK_REPO }}
+        run: |
+          if [ "$IS_FORK_REPO" != "true" ]; then
+            echo "::error::IS_FORK_REPO is not set to 'true' (got: '${IS_FORK_REPO:-<unset>}'). Refusing to run -- this looks like it could be the upstream repo. If this really is your own fork, set the IS_FORK_REPO repository variable (Settings > Secrets and variables > Actions > Variables) to 'true' to enable this workflow." 
+            exit 1
+          fi
+          echo "IS_FORK_REPO confirmed 'true' -- proceeding."
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Start sandbox container
+        env:
+          CONTAINER_NAME: applet-${{ github.run_id }}
+          WORKSPACE_HOST_LOCATION: ${{ github.workspace }}
+        run: docker compose up -d
+
+      - name: Run codebase audit agent
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          REVIEWER_PROVIDER: ${{ vars.REVIEWER_PROVIDER }}
+          REVIEWER_MODEL: ${{ vars.REVIEWER_MODEL }}
+          AUDIT_SPEC_PATHS: ${{ inputs.spec_paths }}
+          CONTAINER_NAME: applet-${{ github.run_id }}
+          AI_STUDIO: "false"
+        run: npm run agent:audit
+
+      - name: Stop sandbox container
+        if: always()
+        env:
+          CONTAINER_NAME: applet-${{ github.run_id }}
+          WORKSPACE_HOST_LOCATION: ${{ github.workspace }}
+        run: docker compose down


### PR DESCRIPTION
- workflow-hotswap/audit-codebase.yml: manual workflow_dispatch trigger mirroring run-issue-task.yml's structure (fork guard, sandbox container lifecycle, same secrets/vars wiring), with an optional spec_paths input forwarded as AUDIT_SPEC_PATHS. Only requests issues:write (no pull-requests:write, since this script only ever creates an issue).
- package.json: add 'agent:audit' script running scripts/audit-codebase.ts, mirroring 'agent:issue'.