### PR TITLE
Fix #277: derive autoApprovedTools kinds from availableTools wire names

### DIFF
--- a/src/copilotSdk/hardenedSession.ts
+++ b/src/copilotSdk/hardenedSession.ts
@@ -59,6 +59,69 @@ export type HardenedSessionBaseConfig = Omit<SessionConfig, PolicyOwnedConfigKey
  * `derivePermissionHandler` unconditionally reject them regardless of
  * `autoApprovedTools`.
  */
+/**
+ * Maps a built-in tool's `availableTools` wire name to the permission
+ * `kind` the SDK reports for it in a `PermissionRequest` (see
+ * `extractRequestedToolName` above). This is the single source of truth
+ * issue #277 asks for: `availableTools` and `autoApprovedTools` are
+ * different namespaces for built-ins, and every caller needs the same
+ * mapping between them rather than re-deriving it (or getting it wrong).
+ *
+ * Only wire names actually adopted by this codebase are listed --
+ * `bash`/`view`/`grep`/`glob` (see toolCallEnforcement.ts). Extend this map
+ * before wiring up a new built-in tool rather than guessing its kind: an
+ * absent entry falls through `deriveAutoApprovedTools` unchanged, which is
+ * the "wire name in both lists" failure mode issue #277 was filed over.
+ */
+export const BUILTIN_TOOL_PERMISSION_KIND: Readonly<Record<string, string>> = {
+  bash: 'shell',
+  view: 'read',
+  grep: 'read',
+  glob: 'read',
+};
+
+/**
+ * Derives the correct `autoApprovedTools` list from an `availableTools`
+ * list, so callers ask for capabilities once instead of hand-assembling
+ * two namespaces that have to agree (issue #277). Each entry is mapped
+ * through `BUILTIN_TOOL_PERMISSION_KIND` if it names a known built-in;
+ * anything else (custom tool names, MCP tool names, hook names, or an
+ * already-correct kind like `"read"`) is passed through unchanged, since
+ * `extractRequestedToolName` resolves those cases by `toolName` directly
+ * rather than a fixed kind.
+ */
+export function deriveAutoApprovedTools(availableTools: readonly string[]): string[] {
+  const seen = new Set<string>();
+  for (const name of availableTools) {
+    seen.add(BUILTIN_TOOL_PERMISSION_KIND[name] ?? name);
+  }
+  return [...seen];
+}
+
+/**
+ * Warns (does not throw) when `autoApprovedTools` contains a raw built-in
+ * wire name (e.g. `"bash"`) instead of its permission kind (e.g.
+ * `"shell"`) -- the exact silent-misconfiguration case issue #277 was
+ * filed over: `derivePermissionHandler` checks `autoApprovedTools` against
+ * kinds, so a wire name there never matches and every call to that tool is
+ * rejected, with no error pointing at the actual cause. Callers that
+ * intentionally list a custom/MCP/hook tool whose name happens to collide
+ * with a built-in wire name are not expected -- built-in wire names are
+ * reserved -- so this is a plain warning, not a false-positive-prone check.
+ */
+function warnIfAutoApprovedToolsLooksLikeWireNames(policy: SessionPolicy): void {
+  const misconfigured = policy.autoApprovedTools.filter((name) => name in BUILTIN_TOOL_PERMISSION_KIND);
+  if (misconfigured.length > 0) {
+    console.warn(
+      `[hardenedSession] SessionPolicy.autoApprovedTools contains built-in tool wire name(s) ` +
+      `${misconfigured.map((n) => `'${n}'`).join(', ')} -- autoApprovedTools is checked against ` +
+      `permission *kinds*, not wire names (see BUILTIN_TOOL_PERMISSION_KIND / issue #277). ` +
+      `Did you mean ${misconfigured.map((n) => `'${BUILTIN_TOOL_PERMISSION_KIND[n]}'`).join(', ')}? ` +
+      `Consider building autoApprovedTools via deriveAutoApprovedTools(availableTools) instead.`
+    );
+  }
+}
+
 function extractRequestedToolName(req: PermissionRequest): string {
   switch (req.kind) {
     case 'mcp':
@@ -162,6 +225,7 @@ export function deriveSessionConfig(
   autoApproveAll: false;
   onPermissionRequest: (req: PermissionRequest, invocation: { sessionId: string }) => Promise<PermissionRequestResult>;
 } {
+  warnIfAutoApprovedToolsLooksLikeWireNames(policy);
   return {
     availableTools: [...policy.availableTools] as SessionConfig['availableTools'],
     tools: (policy.tools ? [...policy.tools] : []) as SessionConfig['tools'],

--- a/src/copilotSdk/issue277.test.ts
+++ b/src/copilotSdk/issue277.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  deriveAutoApprovedTools,
+  deriveSessionConfig,
+  BUILTIN_TOOL_PERMISSION_KIND,
+  SessionPolicy,
+} from './hardenedSession';
+
+/**
+ * Regression tests for issue #277: `availableTools` (wire names) and
+ * `autoApprovedTools` (permission kinds) are two different namespaces for
+ * built-in tools, and callers who don't know that get a silently broken
+ * policy.
+ */
+describe('deriveAutoApprovedTools (issue #277)', () => {
+  it('maps known built-in wire names to their permission kind', () => {
+    expect(deriveAutoApprovedTools(['bash'])).toEqual(['shell']);
+    expect(deriveAutoApprovedTools(['view'])).toEqual(['read']);
+    expect(deriveAutoApprovedTools(['grep'])).toEqual(['read']);
+    expect(deriveAutoApprovedTools(['glob'])).toEqual(['read']);
+  });
+
+  it('de-duplicates kinds when multiple wire names collapse to the same kind', () => {
+    expect(deriveAutoApprovedTools(['view', 'grep', 'glob'])).toEqual(['read']);
+  });
+
+  it('passes through names with no known built-in mapping unchanged (custom/MCP/hook tool names)', () => {
+    expect(deriveAutoApprovedTools(['my_custom_tool', 'github-list_issues'])).toEqual([
+      'my_custom_tool',
+      'github-list_issues',
+    ]);
+  });
+
+  it('mixes built-ins and custom tools correctly', () => {
+    expect(deriveAutoApprovedTools(['bash', 'view', 'my_custom_tool'])).toEqual([
+      'shell',
+      'read',
+      'my_custom_tool',
+    ]);
+  });
+
+  it('BUILTIN_TOOL_PERMISSION_KIND only covers the wire names this codebase actually uses', () => {
+    expect(BUILTIN_TOOL_PERMISSION_KIND).toEqual({
+      bash: 'shell',
+      view: 'read',
+      grep: 'read',
+      glob: 'read',
+    });
+  });
+});
+
+describe('deriveSessionConfig warns on misconfigured autoApprovedTools (issue #277)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makePolicy(overrides: Partial<SessionPolicy> = {}): SessionPolicy {
+    return {
+      availableTools: ['bash'],
+      autoApprovedTools: ['bash'],
+      ...overrides,
+    };
+  }
+
+  it('warns when autoApprovedTools contains a raw built-in wire name instead of its kind', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    deriveSessionConfig(makePolicy({ autoApprovedTools: ['bash', 'view'] }));
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0]?.[0] as string;
+    expect(message).toContain("'bash'");
+    expect(message).toContain("'view'");
+    expect(message).toContain('issue #277');
+  });
+
+  it('does not warn when autoApprovedTools correctly uses permission kinds', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    deriveSessionConfig(makePolicy({ autoApprovedTools: ['shell', 'read'] }));
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for a policy with no built-in tools involved at all', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    deriveSessionConfig(makePolicy({ availableTools: ['my_custom_tool'], autoApprovedTools: ['my_custom_tool'] }));
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/toolCallEnforcement.ts
+++ b/src/utils/toolCallEnforcement.ts
@@ -1,5 +1,5 @@
 import { CopilotClient, CopilotSession, SdkProviderConfig as ProviderConfig, SessionConfig, MessageOptions, Tool } from '../copilotSdk/boundary';
-import { registerSessionPolicy, resumeHardenedSession, deleteHardenedSessionPolicy, SessionPolicy } from '../copilotSdk/hardenedSession';
+import { registerSessionPolicy, resumeHardenedSession, deleteHardenedSessionPolicy, deriveAutoApprovedTools, SessionPolicy } from '../copilotSdk/hardenedSession';
 
 /**
  * How much of the model's last assistant message to include when we give up
@@ -347,6 +347,14 @@ export interface ForcedToolTurnOptions<T> {
  * tool in `availableTools` -- matching these functions' pre-#246 behavior of
  * relying on `CopilotClient`'s auto-approve-all resume default -- but scoped
  * to the tools actually allowed for the turn, rather than truly all tools.
+ *
+ * `availableTools` here can include built-in wire names (`bash`/`view`/
+ * `grep`/`glob`), which are a different namespace than the permission
+ * `kind`s `autoApprovedTools` is checked against (issue #277) -- passing
+ * `availableTools` straight through as `autoApprovedTools`, as this used to
+ * do, silently rejected every built-in tool call. `deriveAutoApprovedTools`
+ * maps each wire name to its kind (custom/MCP/hook names pass through
+ * unchanged, since those are matched by name directly).
  */
 function buildResumePolicy(
   availableTools: readonly string[],
@@ -357,7 +365,7 @@ function buildResumePolicy(
     availableTools,
     tools: tools as readonly Tool[] | undefined,
     systemMessage,
-    autoApprovedTools: availableTools,
+    autoApprovedTools: deriveAutoApprovedTools(availableTools),
   };
 }
 


### PR DESCRIPTION
SessionPolicy.availableTools (built-in wire names like 'bash'/'view') and autoApprovedTools (permission kinds like 'shell'/'read') are two different, undocumented namespaces for the same built-in tools. A caller who assumes they're the same gets a policy that's silently broken either way, with no error pointing at the cause.

- Add BUILTIN_TOOL_PERMISSION_KIND, the single source of truth mapping each built-in wire name this codebase uses to its permission kind.
- Add deriveAutoApprovedTools(availableTools) to derive the correct autoApprovedTools list in one step instead of hand-assembling both lists.
- Warn (not throw) in deriveSessionConfig when autoApprovedTools contains a raw wire name instead of a kind, so the mistake surfaces immediately instead of as an unexplained 'tool not being used'.
- Fix toolCallEnforcement.ts's buildResumePolicy, which had exactly this bug: it passed availableTools straight through as autoApprovedTools, which silently rejects every built-in tool call on a stall/nudge resume.