### PR TITLE
Fix #283: nothing-to-review gap, category schema gap, status prompt w…

### DIFF
--- a/scripts/review-agent-spec.md
+++ b/scripts/review-agent-spec.md
@@ -104,8 +104,8 @@ modules should be brought into compliance with, not a record of current behavior
 ## 5. Finding Classification
 
 - **U-5.1** Each finding shall carry a `severity` of `blocking`, `suggestion`, or `nit`.
-- **O-5.2** Each finding may carry an optional `category` of `bug`, `security`, `performance`,
-  or `style`, independent of `severity`.
+- **U-5.2** Each finding shall carry a `category` of `bug`, `security`, `performance`, `style`,
+  or `other` (when none of the preceding apply), independent of `severity`.
 - **U-5.3** Each finding shall carry `file`, optional `line`, and `message`.
 - **U-5.4** The system shall instruct the model to keep each finding's `message` concise (target:
   under ~150 words) unless a code snippet is necessary for clarity.

--- a/scripts/review-pr.ts
+++ b/scripts/review-pr.ts
@@ -32,7 +32,7 @@ import {
 
 interface CodeReviewFinding {
   severity: 'blocking' | 'suggestion' | 'nit';
-  category?: 'bug' | 'security' | 'performance' | 'style';
+  category: 'bug' | 'security' | 'performance' | 'style' | 'other';
   file: string;
   line?: number;
   message: string;
@@ -84,12 +84,15 @@ function resolveDiffRange(
   baseSha: string,
   headSha: string,
   previousState: ReviewState | null,
-): { range: string; incremental: boolean } {
+): { range: string; incremental: boolean; nothingToReview?: true } {
   if (!previousState) {
     return { range: `${baseSha}...${headSha}`, incremental: false };
   }
   if (previousState.lastReviewedSha === headSha) {
-    return { range: `${baseSha}...${headSha}`, incremental: false };
+    // Already reviewed this exact head -- nothing new since last time, so
+    // don't fall back to a full base...head diff (that would repost the
+    // entire review on every unchanged re-run).
+    return { range: `${baseSha}...${headSha}`, incremental: false, nothingToReview: true };
   }
   if (!isCommitReachable(previousState.lastReviewedSha)) {
     console.warn(
@@ -152,7 +155,7 @@ Read \`.review-context/comments.md\` to determine if previously reported blockin
 - Treat a prior finding as still open unless the comment history and current diff together indicate it was addressed — i.e., silence in the incremental diff about a prior finding is not evidence of resolution.
 - Do not re-raise a prior finding as newly reported once you judge it addressed; instead, acknowledge it as 'resolved' in the finding output.
 - When a fix introduced in response to prior feedback is found to have introduced a new issue that did not previously exist, raise it as a new finding (regression check).
-- Only set the 'status' field to 'still-open' or 'resolved' on findings that correspond to a prior finding from the comment history.`
+- The 'status' field is always required: default it to 'new', and only use 'still-open' or 'resolved' when the finding corresponds to a prior finding from the comment history.`
     : `This is a full review of the entire PR diff in \`.review-context/diff.patch\`.`}
 
 You must not answer conversationally and must strictly invoke 'submit_code_review'.
@@ -182,7 +185,11 @@ async function main() {
   const comments = fetchComments(prNumber);
 
   const previousState = loadPreviousReviewState(prNumber, comments);
-  const { range, incremental } = resolveDiffRange(baseSha, headSha, previousState);
+  const { range, incremental, nothingToReview } = resolveDiffRange(baseSha, headSha, previousState);
+  if (nothingToReview) {
+    console.log(`Head ${headSha} already reviewed, nothing new to review, skipping.`);
+    process.exit(0);
+  }
   const diff = getFilteredDiff(range);
   if (!diff.trim()) {
     console.log(`No diff to review for range ${range}, skipping.`);

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -206,8 +206,8 @@ export const submitCodeReviewTool = {
               },
               category: {
                 type: "string",
-                enum: ["bug", "security", "performance", "style"],
-                description: "Optional category of the finding."
+                enum: ["bug", "security", "performance", "style", "other"],
+                description: "Category of the finding. Use 'other' when none of bug/security/performance/style applies."
               },
               file: { type: "string", description: "File path the finding applies to." },
               line: { type: "number", description: "Line number in the new version of the file, if applicable." },


### PR DESCRIPTION
…ording

1. resolveDiffRange now signals nothingToReview when lastReviewedSha == headSha; main() checks it and exits cleanly before the diff.trim() gate, so a re-run on an unchanged head no longer reposts the full review.
2. Added 'other' to the category enum (schema + CodeReviewFinding), kept category required, and updated spec O-5.2 -> U-5.2 accordingly.
3. Reworded the incremental-review system prompt's status guidance so it no longer implies withholding the field; status defaults to 'new' and is always required, matching the schema.
Fix #283