### PR TITLE
Fix #299: Give auditor/reviewer sessions a path to the centralized ex…

### DIFF
--- a/src/test/auditor_default_toolset.test.ts
+++ b/src/test/auditor_default_toolset.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Issue #299: session builders like buildAuditorSessionSettings only
+// assembled a task-specific submission tool, so any session built from it
+// fell back to the copilot SDK's own default bash/view/edit tools acting
+// directly on CopilotClient.workingDirectory -- entirely bypassing the
+// app's centralized workspace abstraction (GitSandbox locking,
+// GIT_TIMEOUT_MS/EXEC_TIMEOUT_MS enforcement, Docker-vs-native routing).
+//
+// This guards the fix structurally: every session assembled by the shared
+// builder must include `run_terminal_docker`, and that tool's handler must
+// actually route through the centralized `getExecCommand()` -- not just be
+// present by name with a dead handler.
+
+const mockExecCommand = vi.fn(async () => ({ stdout: 'ok', stderr: '', exitCode: 0 }));
+
+vi.mock('../workspace', () => ({
+  getExecCommand: () => mockExecCommand,
+}));
+
+import { buildAuditorSessionSettings } from '../utils/auditorHelper';
+import { RUN_TERMINAL_DOCKER_TOOL } from '../config/tools';
+
+describe('buildAuditorSessionSettings default toolset (issue #299)', () => {
+  beforeEach(() => {
+    mockExecCommand.mockClear();
+  });
+
+  it('includes run_terminal_docker alongside the task-specific tool by default', () => {
+    const settings = buildAuditorSessionSettings(
+      { model: 'mock-model', provider: undefined } as never,
+      'system prompt',
+      {
+        function: {
+          name: 'submit_task_result',
+          description: 'Submit result',
+          parameters: { type: 'object', properties: {} },
+        },
+      },
+      () => {},
+    );
+
+    const toolNames = settings.tools.map((t) => t.name);
+    expect(toolNames).toContain('submit_task_result');
+    expect(toolNames).toContain(RUN_TERMINAL_DOCKER_TOOL.function.name);
+  });
+
+  it("run_terminal_docker's handler routes through the centralized getExecCommand(), not a stub", async () => {
+    const settings = buildAuditorSessionSettings(
+      { model: 'mock-model', provider: undefined } as never,
+      'system prompt',
+      {
+        function: {
+          name: 'submit_task_result',
+          description: 'Submit result',
+          parameters: { type: 'object', properties: {} },
+        },
+      },
+      () => {},
+    );
+
+    const execTool = settings.tools.find((t) => t.name === RUN_TERMINAL_DOCKER_TOOL.function.name);
+    expect(execTool).toBeDefined();
+
+    const result = await execTool!.handler({ command: 'echo hi' });
+    expect(mockExecCommand).toHaveBeenCalledWith('echo hi', undefined);
+    expect(result).toMatchObject({ stdout: 'ok', stderr: '', exitCode: 0 });
+  });
+
+  it('blocks workingDir path traversal without ever calling getExecCommand()', async () => {
+    const settings = buildAuditorSessionSettings(
+      { model: 'mock-model', provider: undefined } as never,
+      'system prompt',
+      {
+        function: {
+          name: 'submit_task_result',
+          description: 'Submit result',
+          parameters: { type: 'object', properties: {} },
+        },
+      },
+      () => {},
+    );
+
+    const execTool = settings.tools.find((t) => t.name === RUN_TERMINAL_DOCKER_TOOL.function.name);
+    const result = await execTool!.handler({ command: 'ls', workingDir: '../../etc' });
+    expect(mockExecCommand).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ exitCode: 1 });
+  });
+});

--- a/src/test/toolCallEnforcementUntilTimeout.test.ts
+++ b/src/test/toolCallEnforcementUntilTimeout.test.ts
@@ -124,6 +124,35 @@ describe('runForcedToolTurnUntilTimeout', () => {
     expect(mockClient.resumeSession).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves an explicit availableTools set (not narrowed to targetTools) across a nudge-retry resume (issue #299 regression)', async () => {
+    let callCount = 0;
+    const mockSession = {
+      sessionId: 'test-session',
+      on: vi.fn().mockReturnValue(vi.fn()),
+      sendAndWait: vi.fn().mockImplementation(async () => {
+        callCount++;
+      }),
+    } as any;
+
+    const mockClient = {
+      resumeSession: vi.fn().mockImplementation(async (_id, opts) => {
+        expect(opts.availableTools).toEqual(['my_tool', 'run_terminal_docker']);
+        return mockSession;
+      }),
+    } as any;
+
+    const runPromise = runForcedToolTurnUntilTimeout(mockSession, {}, 'my_tool', 'test prompt', {
+      client: mockClient,
+      maxRetries: 1,
+      getResult: () => null,
+      tools: [],
+      availableTools: ['my_tool', 'run_terminal_docker'],
+    });
+
+    await expect(runPromise).rejects.toThrow(/Session ended without calling 'my_tool'/);
+    expect(mockClient.resumeSession).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects on abort signal without touching resumeSession', async () => {
     const abortController = new AbortController();
     const mockSession = {

--- a/src/utils/auditorHelper.ts
+++ b/src/utils/auditorHelper.ts
@@ -2,6 +2,10 @@ import { runForcedToolTurnUntilTimeout } from './toolCallEnforcement';
 import { CopilotClient, SdkProviderConfig, SessionConfig, CopilotSession, PermissionRequest, PermissionRequestResult } from '../copilotSdk/boundary';
 import { ProviderRegistry, ExecutionConfig } from './providerRegistry';
 import { DEFAULT_ROLES_CONFIG, getAuditorTierConfig, selectFromAuditorPool, ModelProviderConfig } from '../config/models';
+import { RUN_TERMINAL_DOCKER_TOOL } from '../config/tools';
+import { getExecCommand } from '../workspace';
+import { truncateOutput } from './formatters';
+import { sanitizeSensitives } from './sanitizers';
 
 /**
  * Tool-usage guidance carried over from the base CLI system prompt.
@@ -218,6 +222,40 @@ export function getReviewerExecutionConfig(apiKey?: string): ExecutionConfig {
 }
 
 /**
+ * Headless (non-SSE) handler for `run_terminal_docker` in auditor/reviewer
+ * sessions -- these sessions have no `res`/`secureWrite` SSE stream to push
+ * `tool.result` events onto (see `makeDockerToolHandler` in toolHandlers.ts,
+ * which requires both), just a plain request/response tool call.
+ *
+ * Routes through `getExecCommand()` (see SYS-REQ-020/023) exactly like the
+ * SSE variant, so auditor sessions get the same GitSandbox locking,
+ * GIT_TIMEOUT_MS/EXEC_TIMEOUT_MS enforcement, and Docker-vs-native routing
+ * as every other centralized-workspace consumer, instead of falling back to
+ * the copilot SDK's own default bash/view/edit tools operating directly on
+ * `CopilotClient.workingDirectory` (issue #299).
+ */
+function makeAuditorExecToolHandler(abortSignal?: AbortSignal) {
+  return async (args: unknown) => {
+    const record = args as Record<string, unknown>;
+    const wd = (record.workingDir as string) || '';
+    if (wd.includes('..')) {
+      return {
+        stdout: '',
+        stderr: 'Error: Directory path traversal detected. Access denied outside workspace boundaries.',
+        exitCode: 1,
+      };
+    }
+    const execCommand = getExecCommand();
+    const result = await execCommand((record.command as string) || '', abortSignal);
+    return {
+      stdout: truncateOutput(sanitizeSensitives(result.stdout)),
+      stderr: truncateOutput(sanitizeSensitives(result.stderr)),
+      exitCode: result.exitCode,
+    };
+  };
+}
+
+/**
  * Shared session settings for auditors:
  * - No-conversational-reply enforcement (via systemPrompt)
  * - Tool-specific permission guarding
@@ -233,9 +271,11 @@ export function buildAuditorSessionSettings(
   executionConfig: ExecutionConfig,
   systemPrompt: string,
   tool: ToolDefinition,
-  onResult: (result: unknown) => void
+  onResult: (result: unknown) => void,
+  abortSignal?: AbortSignal
 ) {
   const toolName = tool.function.name;
+  const execToolName = RUN_TERMINAL_DOCKER_TOOL.function.name;
   return {
     model: executionConfig.model,
     ...(executionConfig.provider ? { provider: executionConfig.provider as SdkProviderConfig } : {}),
@@ -265,6 +305,18 @@ export function buildAuditorSessionSettings(
         mode: "replace",
         content: `${TOOL_USAGE_BOILERPLATE}\n\n${systemPrompt}`,
     },
+    // Issue #299: session builders here previously only assembled the
+    // task-specific submission tool, so any session built from this
+    // function fell back to the copilot SDK's own built-in bash/view/edit
+    // tools operating directly on `CopilotClient.workingDirectory` --
+    // entirely bypassing the app's centralized workspace abstraction (no
+    // GitSandbox locking, no timeout enforcement, no Docker-vs-native
+    // routing; exactly the class of bypass SYS-REQ-020a calls out).
+    // `run_terminal_docker` is now included by default for every consumer
+    // of this shared builder (executeAuditSession and, transitively,
+    // specAuditor/complianceAudit/pbiDerivation/review-pr.ts) rather than
+    // opted into per-caller. See auditor_default_toolset.test.ts for the
+    // regression guard.
     tools: [
       {
         name: toolName,
@@ -274,6 +326,12 @@ export function buildAuditorSessionSettings(
           onResult(args);
           return { status: 'received' };
         }
+      },
+      {
+        name: execToolName,
+        description: RUN_TERMINAL_DOCKER_TOOL.function.description,
+        parameters: RUN_TERMINAL_DOCKER_TOOL.function.parameters,
+        handler: makeAuditorExecToolHandler(abortSignal),
       }
     ],
     // NOTE: this onPermissionRequest is currently unreachable in practice --
@@ -291,10 +349,11 @@ export function buildAuditorSessionSettings(
                             (Array.isArray(record.toolCalls) && record.toolCalls[0] && typeof record.toolCalls[0] === 'object'
                               ? ((record.toolCalls[0] as Record<string, unknown>).function as Record<string, unknown> | undefined)?.name as string | undefined
                               : undefined);
-      const allowed = !requestedTool || requestedTool === toolName || 
-                      (Array.isArray(record.toolCalls) && record.toolCalls.every((tc: unknown) => 
-                        tc && typeof tc === 'object' && ((tc as Record<string, unknown>).function as Record<string, unknown> | undefined)?.name === toolName));
-      return allowed ? { kind: 'approve-once' } : { kind: 'reject', feedback: 'Auditor sessions must not execute tools.' };
+      const allowedToolNames = [toolName, execToolName];
+      const allowed = !requestedTool || allowedToolNames.includes(requestedTool) ||
+                      (Array.isArray(record.toolCalls) && record.toolCalls.every((tc: unknown) =>
+                        tc && typeof tc === 'object' && allowedToolNames.includes(((tc as Record<string, unknown>).function as Record<string, unknown> | undefined)?.name as string)));
+      return allowed ? { kind: 'approve-once' } : { kind: 'reject', feedback: `Auditor sessions may only call ${toolName} or ${execToolName}.` };
     },
     streaming: false,
   };
@@ -339,7 +398,8 @@ export async function executeAuditSession<T>(
       executionConfig,
       systemPrompt,
       tool,
-      (args) => { result = args as T; }
+      (args) => { result = args as T; },
+      abortSignal
     );
 
     let session: CopilotSession;
@@ -360,6 +420,11 @@ export async function executeAuditSession<T>(
       maxRetries,
       getResult: () => result,
       tools: sessionSettings.tools,
+      // Explicit, not left to the [toolName]-only default: without this, a
+      // stall/nudge resume's SessionPolicy would silently drop
+      // run_terminal_docker from the allowlist even though it's still
+      // present in `tools` above (issue #299).
+      availableTools: [toolName, RUN_TERMINAL_DOCKER_TOOL.function.name],
       systemMessage: sessionSettings.systemMessage as SessionConfig['systemMessage'],
       responseRequirements,
       onSessionId: (id) => {

--- a/src/utils/auditorHelper.ts
+++ b/src/utils/auditorHelper.ts
@@ -420,10 +420,15 @@ export async function executeAuditSession<T>(
       maxRetries,
       getResult: () => result,
       tools: sessionSettings.tools,
-      // Explicit, not left to the [toolName]-only default: without this, a
-      // stall/nudge resume's SessionPolicy would silently drop
-      // run_terminal_docker from the allowlist even though it's still
-      // present in `tools` above (issue #299).
+      // Explicit, not left to the [toolName]-only default: runForcedToolTurnUntilTimeout's
+      // nudge-retry resume rebuilds its SessionPolicy from opts.availableTools
+      // (see toolCallEnforcement.ts) each time it resumes, so without this the
+      // resumed session would silently lose run_terminal_docker from its
+      // allowlist after the first nudge, even though it's still present in
+      // `tools` above (issue #299). (There is no separate stall-recovery path
+      // in this function -- only the nudge-retry loop -- fixed alongside this
+      // in toolCallEnforcement.ts, which previously ignored opts.availableTools
+      // here and always collapsed the resume policy to just [toolName].)
       availableTools: [toolName, RUN_TERMINAL_DOCKER_TOOL.function.name],
       systemMessage: sessionSettings.systemMessage as SessionConfig['systemMessage'],
       responseRequirements,

--- a/src/utils/toolCallEnforcement.ts
+++ b/src/utils/toolCallEnforcement.ts
@@ -830,7 +830,7 @@ export async function runForcedToolTurnUntilTimeout<T>(
 
     registerSessionPolicy(
       currentSessionId,
-      buildResumePolicy(targetTools, opts.tools, opts.systemMessage)
+      buildResumePolicy(opts.availableTools ?? targetTools, opts.tools, opts.systemMessage)
     );
     currentSession = await resumeHardenedSession(
       opts.client,


### PR DESCRIPTION
…… (#309)

…ecution tool

buildAuditorSessionSettings only assembled the task-specific submission tool (e.g. submit_task_result), so every session built by executeAuditSession
- and transitively specAuditor, complianceAudit, pbiDerivation, and review-pr.ts - fell back to the copilot SDK's own default bash/view/edit tools operating directly on CopilotClient.workingDirectory. That bypasses GitSandbox locking, GIT_TIMEOUT_MS/EXEC_TIMEOUT_MS enforcement, and Docker-vs-native routing entirely (SYS-REQ-020a).

- Add run_terminal_docker to the tool set buildAuditorSessionSettings assembles by default, with a headless (non-SSE) handler that routes through getExecCommand(), mirroring the SSE handler's traversal guard, truncation, and sanitization.
- Widen the (currently-unreachable but not dead) onPermissionRequest allowlist to cover both the target tool and run_terminal_docker.
- Pass availableTools: [toolName, run_terminal_docker] explicitly into runForcedToolTurnUntilTimeout so a stall/nudge resume doesn't silently drop the exec tool from the allowlist.
- Add auditor_default_toolset.test.ts as the regression guard the issue asked for: fails if the shared builder's tools array omits run_terminal_docker, and asserts the handler actually calls getExecCommand() rather than being present by name only.

Fix #299