### PR TITLE
Fix #300: Add desktop runner mode for getRunner()

### DIFF
--- a/src/test/workspace_runner_selection.test.ts
+++ b/src/test/workspace_runner_selection.test.ts
@@ -1,0 +1,82 @@
+import { assert, describe, it, vi, afterEach } from "vitest";
+
+// getRunner() treats NODE_ENV=test / VITEST=true as AI Studio mode (so the
+// rest of the suite gets a safe native runner by default). To exercise the
+// docker/desktop branches we have to explicitly unset those here, on top of
+// the mode-selecting vars, then restore everything afterward.
+const ENV_KEYS = ["AI_STUDIO", "NODE_ENV", "VITEST", "RUNNER_MODE", "WORKSPACE_HOST_LOCATION"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+afterEach(() => {
+  vi.resetModules();
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+function clearRunnerEnv() {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+}
+
+describe("getRunner() mode selection", () => {
+  it("selects the native runner in AI Studio mode", async () => {
+    clearRunnerEnv();
+    process.env.AI_STUDIO = "true";
+    vi.resetModules();
+
+    const workspace = await import("../workspace/workspace.js");
+    const native = await import("../workspace/nativeRunner.js");
+
+    assert.strictEqual(workspace.getWorkspaceRoot(), native.getWorkspaceRoot());
+  });
+
+  it("selects the desktop runner when RUNNER_MODE=desktop outside AI Studio", async () => {
+    clearRunnerEnv();
+    process.env.RUNNER_MODE = "desktop";
+    process.env.WORKSPACE_HOST_LOCATION = "/host/project";
+    vi.resetModules();
+
+    const workspace = await import("../workspace/workspace.js");
+
+    assert.strictEqual(workspace.getWorkspaceRoot(), "/host/project");
+    assert.strictEqual(workspace.getWorkspaceHostLocation(), "/host/project");
+  });
+
+  it("falls back to the docker runner when neither AI Studio nor desktop mode apply", async () => {
+    clearRunnerEnv();
+    vi.resetModules();
+
+    const workspace = await import("../workspace/workspace.js");
+    const docker = await import("../workspace/dockerRunner.js");
+
+    assert.strictEqual(workspace.getWorkspaceRoot(), docker.getWorkspaceRoot());
+  });
+
+  it("prioritizes AI Studio mode over an explicit desktop RUNNER_MODE", async () => {
+    clearRunnerEnv();
+    process.env.AI_STUDIO = "true";
+    process.env.RUNNER_MODE = "desktop";
+    process.env.WORKSPACE_HOST_LOCATION = "/host/project";
+    vi.resetModules();
+
+    const workspace = await import("../workspace/workspace.js");
+
+    // nativeRunner mints a fresh mkdtemp dir per import, so compare against
+    // its known naming pattern rather than a second import's exact value.
+    assert.match(workspace.getWorkspaceRoot(), /^\/tmp\/app-/);
+  });
+
+  it("desktop mode throws without WORKSPACE_HOST_LOCATION set", async () => {
+    clearRunnerEnv();
+    process.env.RUNNER_MODE = "desktop";
+    vi.resetModules();
+
+    const workspace = await import("../workspace/workspace.js");
+
+    assert.throws(() => workspace.getWorkspaceRoot());
+  });
+});

--- a/src/workspace/desktopRunner.ts
+++ b/src/workspace/desktopRunner.ts
@@ -1,0 +1,144 @@
+import { spawn } from "child_process";
+import { killProcessGroup } from "./processGroup";
+
+// Unlike nativeRunner's AI Studio mode — which mints an ephemeral mkdtemp
+// scratch directory — desktop mode operates directly on a real host project
+// checkout, so the root must be supplied explicitly rather than invented.
+function getWorkspaceRootOrThrow(): string {
+  const root = process.env.WORKSPACE_HOST_LOCATION;
+  if (!root) {
+    throw new Error(
+      "WORKSPACE_HOST_LOCATION environment variable is not set. Desktop runner mode requires it to point at the host project directory."
+    );
+  }
+  return root;
+}
+
+const FIXED_PATH = "/usr/local/bin:/usr/bin:/bin";
+
+// Default timeout for user-supplied commands. Callers can override by passing
+// their own AbortSignal; this deadline applies only when none is provided.
+const EXEC_TIMEOUT_MS = 60_000;
+
+/**
+ * Executes a command natively on the desktop host, rooted at
+ * WORKSPACE_HOST_LOCATION. Mirrors nativeRunner's runNativeProcess, but runs
+ * against a real project checkout instead of an ephemeral scratch directory.
+ */
+export async function runDesktopProcess(
+  command: string,
+  signal?: AbortSignal,
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  return new Promise((resolve) => {
+    const child = spawn("bash", ["-s"], {
+      cwd: getWorkspaceRootOrThrow(),
+      env: process.env.NODE_ENV === "test" || process.env.VITEST === "true" ? process.env : { PATH: FIXED_PATH },
+      detached: true,
+    });
+
+    const killChild = () => killProcessGroup(child);
+
+    const onAbort = () => killChild();
+    if (signal) {
+      signal.addEventListener("abort", onAbort);
+      if (signal.aborted) {
+        killChild();
+        // Wait for the OS to actually reap the process group before
+        // resolving, rather than assuming SIGKILL took effect the instant
+        // it was sent — mirrors the docker/native runners' wait-for-cleanup
+        // behavior so callers get consistent "resolved means dead" semantics
+        // across all three runners. Bounded by the same style of fallback
+        // timer used elsewhere in this file in case close never fires.
+        const timer = setTimeout(() => {
+          child.removeAllListeners("close");
+          resolve({ stdout: "", stderr: "Desktop process aborted", exitCode: 1 });
+        }, 1000);
+        child.once("close", () => {
+          clearTimeout(timer);
+          resolve({ stdout: "", stderr: "Desktop process aborted", exitCode: 1 });
+        });
+        return;
+      }
+    }
+
+    child.on("error", (err: any) => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+      resolve({
+        stdout: "",
+        stderr: `Failed to spawn desktop process: ${err.message}`,
+        exitCode: 127,
+      });
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+    child.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    child.on("close", (code) => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+      resolve({ stdout, stderr, exitCode: code });
+    });
+
+    if (child.stdin.writable) {
+      child.stdin.write(command + "\n");
+      child.stdin.end();
+    } else {
+      if (signal) signal.removeEventListener("abort", onAbort);
+      killChild();
+
+      // Wait for the process to fully exit before resolving. A fallback timer
+      // guards against close never firing (e.g. the process ignores SIGKILL).
+      // Whichever branch wins cancels the other to ensure resolve() is called
+      // exactly once and neither handler is left dangling.
+      const timer = setTimeout(() => {
+        child.removeAllListeners("close");
+        resolve({
+          stdout: "",
+          stderr: "Desktop process stdin not writable — timeout waiting for close.",
+          exitCode: 1,
+        });
+      }, 1000);
+
+      child.once("close", () => {
+        clearTimeout(timer);
+        resolve({
+          stdout: "",
+          stderr: "Desktop process stdin not writable — process failed to start.",
+          exitCode: 1,
+        });
+      });
+    }
+  });
+}
+
+/**
+ * Executes a command natively on the desktop host. Mirrors the execCommand
+ * interface from dockerRunner.ts/nativeRunner.ts for use in desktop mode.
+ *
+ * If no AbortSignal is supplied, a default timeout of EXEC_TIMEOUT_MS is
+ * applied to prevent LLM-generated commands from hanging indefinitely.
+ */
+export async function execCommand(
+  command: string,
+  signal?: AbortSignal,
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  return runDesktopProcess(command, signal ?? AbortSignal.timeout(EXEC_TIMEOUT_MS));
+}
+
+export function getWorkspaceRoot(): string {
+  return getWorkspaceRootOrThrow();
+}
+
+export function getWorkspaceHostLocation(): string {
+  return getWorkspaceRootOrThrow();
+}
+
+export function getGitDir(): string {
+  return getWorkspaceRootOrThrow() + "/snapshots/.git";
+}

--- a/src/workspace/workspace.ts
+++ b/src/workspace/workspace.ts
@@ -1,13 +1,23 @@
 import * as docker from "./dockerRunner";
 import * as native from "./nativeRunner";
+import * as desktop from "./desktopRunner";
 import { GitSandbox } from "./git";
 
 function isAIStudio(): boolean {
   return process.env.AI_STUDIO === "true" || process.env.NODE_ENV === "test" || process.env.VITEST === "true";
 }
 
+// Distinct from AI Studio's native mode: AI Studio's nativeRunner mints an
+// ephemeral mkdtemp workspace, whereas desktop mode runs against a real host
+// project checkout (rooted at WORKSPACE_HOST_LOCATION, see desktopRunner.ts).
+function isDesktop(): boolean {
+  return process.env.RUNNER_MODE === "desktop";
+}
+
 function getRunner() {
-  return isAIStudio() ? native : docker;
+  if (isAIStudio()) return native;
+  if (isDesktop()) return desktop;
+  return docker;
 }
 
 // Shared singleton — one instance means one busy flag, so withLock


### PR DESCRIPTION
Adds a third mode alongside AI Studio (native) and Docker: desktop mode, selected via RUNNER_MODE=desktop, resolves the workspace root from WORKSPACE_HOST_LOCATION (the real host project checkout) instead of AI Studio's ephemeral mkdtemp workspace or Docker's container mount.

- New src/workspace/desktopRunner.ts: native process execution rooted at WORKSPACE_HOST_LOCATION, throws clearly if that env var is unset.
- workspace.ts: getRunner() now checks isDesktop() (RUNNER_MODE=desktop) between the existing isAIStudio() and Docker fallback branches.
- New test covering getRunner()'s branching itself (previously untested at the boundary).

Fix #300