### PR TITLE
Fix #301: Extract pure selectRunnerMode() from getRunner()

### DIFF
--- a/src/test/select_runner_mode.test.ts
+++ b/src/test/select_runner_mode.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { selectRunnerMode } from "../workspace/workspace";
+
+describe("selectRunnerMode (pure, issue #301)", () => {
+  it("selects native when AI_STUDIO is 'true'", () => {
+    expect(selectRunnerMode({ AI_STUDIO: "true" })).toBe("native");
+  });
+
+  it("selects native when NODE_ENV is 'test'", () => {
+    expect(selectRunnerMode({ NODE_ENV: "test" })).toBe("native");
+  });
+
+  it("selects native when VITEST is 'true'", () => {
+    expect(selectRunnerMode({ VITEST: "true" })).toBe("native");
+  });
+
+  it("selects docker when none of the env flags are set", () => {
+    expect(selectRunnerMode({})).toBe("docker");
+  });
+
+  it("selects docker when flags are set to other values", () => {
+    expect(
+      selectRunnerMode({ AI_STUDIO: "false", NODE_ENV: "production", VITEST: "false" })
+    ).toBe("docker");
+  });
+});

--- a/src/workspace/workspace.ts
+++ b/src/workspace/workspace.ts
@@ -2,12 +2,31 @@ import * as docker from "./dockerRunner";
 import * as native from "./nativeRunner";
 import { GitSandbox } from "./git";
 
+export type RunnerMode = "native" | "docker";
+
+/**
+ * Pure decision logic for issue #301: given explicit env inputs, decide
+ * which runner mode applies. No process.env reads, no I/O -- takes the
+ * three relevant env values as arguments so it can be unit-tested
+ * exhaustively without mocking process.env or triggering real
+ * process/container behavior.
+ */
+export function selectRunnerMode(env: {
+  AI_STUDIO?: string;
+  NODE_ENV?: string;
+  VITEST?: string;
+}): RunnerMode {
+  return env.AI_STUDIO === "true" || env.NODE_ENV === "test" || env.VITEST === "true"
+    ? "native"
+    : "docker";
+}
+
 function isAIStudio(): boolean {
-  return process.env.AI_STUDIO === "true" || process.env.NODE_ENV === "test" || process.env.VITEST === "true";
+  return selectRunnerMode(process.env) === "native";
 }
 
 function getRunner() {
-  return isAIStudio() ? native : docker;
+  return selectRunnerMode(process.env) === "native" ? native : docker;
 }
 
 // Shared singleton — one instance means one busy flag, so withLock


### PR DESCRIPTION
Splits workspace.ts's getRunner() mode-selection logic into a pure function (env in, RunnerMode out, no I/O) and a thin wrapper that reads process.env and dispatches to the native/docker runner module. Adds unit tests covering the pure function in isolation, without mocking process.env or triggering real process/container behavior.

Fix #301