### PR TITLE
Increase codebase auditor timeout to 30 minutes

### DIFF
--- a/scripts/audit-codebase.ts
+++ b/scripts/audit-codebase.ts
@@ -240,7 +240,7 @@ async function main() {
 
     console.log('[audit-codebase] sending task and waiting for completion...');
     const turnResult = await runForcedToolTurnUntilTimeout(wrapper, RUN_GH_COMMAND_TOOL_NAME, userPrompt, {
-      timeoutMs: 900000,
+      timeoutMs: 1800000, // 30 minutes
       maxRetries: 2,
       getResult: () => undefined,
       availableTools,


### PR DESCRIPTION
The auditor workflow's forced tool turn was capped at a hard 15-minute (900000ms) timeout with no extension, causing runs to be killed even while the agent was still making progress. Bump to 30 minutes.