### PR TITLE
Fix #346 review nit: cleanup isPersistent guard dead for wrapper-back…

### DIFF
--- a/src/orchestrator/gateLoop.ts
+++ b/src/orchestrator/gateLoop.ts
@@ -722,10 +722,12 @@ export const handleGateLoop = async (
       try {
         if (session) {
           // If the session is part of the persistent activeSessions, do NOT disconnect here.
-          // Disconnecting would break context retention for future turns using getOrCreateSession.
+          // Disconnecting would break context retention for future turns using getOrCreateSession/getOrCreateSessionWrapper.
           // The global GC interval handles pruning inactive persistent sessions.
           const isPersistent = Array.from(activeSessions.values()).some(
-            (s) => s.copilotSession === session,
+            (s) =>
+              s.copilotSession === session ||
+              s.sessionWrapper?.session === session,
           );
           if (!isPersistent) {
             await session.disconnect();


### PR DESCRIPTION
…ed sessions

The end-of-request cleanup's isPersistent check only compared s.copilotSession === session, which is always false for a wrapper-backed record (getOrCreateSessionWrapper stores copilotSession: null, sessionState.ts ~516). So the main-loop session was disconnected at end-of-request even when cached in activeSessions, defeating the guard's documented intent and losing context retention/the warm server-side prompt cache before the next request's resumeSession (not a correctness break -- resumeSession recovers conversation state -- but an avoidable disconnect/resume round trip per request).

Fix: also recognize s.sessionWrapper?.session === session as persistent.

373/373 tests passing, tsc --noEmit clean.