### PR TITLE
Fix #415: Extract self-contained session unit (src/agentSessionCore/)

### DIFF
--- a/src/agentSessionCore/execTool.test.ts
+++ b/src/agentSessionCore/execTool.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createExecTool, createExecToolHandler } from './execTool';
+
+vi.mock('../workspace', () => ({
+  getExecCommand: () => async (command: string) => ({
+    stdout: `ran: ${command}`,
+    stderr: '',
+    exitCode: 0,
+  }),
+}));
+
+describe('createExecTool / createExecToolHandler (SYS-REQ-029b/029d)', () => {
+  it('produces a tool definition matching the canonical run_terminal_docker schema', () => {
+    const tool = createExecTool();
+    expect(tool.name).toBe('run_terminal_docker');
+    expect(tool.parameters).toMatchObject({ required: ['command'] });
+    expect(typeof tool.handler).toBe('function');
+  });
+
+  it('blocks working-directory traversal identically regardless of delivery mode', async () => {
+    const unstreamed = createExecToolHandler();
+    const delivered: unknown[] = [];
+    const streamed = createExecToolHandler({ onDeliver: (e) => { delivered.push(e); } });
+
+    const argsWithTraversal = { command: 'ls', workingDir: '../etc' };
+    const resultA = await unstreamed(argsWithTraversal);
+    const resultB = await streamed(argsWithTraversal);
+
+    expect(resultA).toEqual(resultB);
+    expect(resultA.exitCode).toBe(1);
+    expect(resultA.stderr).toMatch(/traversal/i);
+    // Traversal is rejected before exec, so nothing should have been delivered.
+    expect(delivered).toHaveLength(0);
+  });
+
+  it('runs the command and sanitizes/truncates output the same way across delivery modes', async () => {
+    const unstreamed = createExecToolHandler();
+    const delivered: unknown[] = [];
+    const streamed = createExecToolHandler({ onDeliver: (e) => { delivered.push(e); } });
+
+    const args = { command: 'echo hi' };
+    const resultA = await unstreamed(args);
+    const resultB = await streamed(args);
+
+    expect(resultA).toEqual(resultB);
+    expect(resultA.stdout).toBe('ran: echo hi');
+    expect(delivered).toEqual([
+      { toolName: 'run_terminal_docker', stdout: 'ran: echo hi', stderr: '', exitCode: 0 },
+    ]);
+  });
+
+  it('never consults orchestration-session state itself (SYS-REQ-029e)', async () => {
+    // No orchestrator import anywhere in this module -- executing the
+    // handler with no active session context at all must still succeed,
+    // proving availability is decided one layer up, not in the handler.
+    const handler = createExecToolHandler();
+    const result = await handler({ command: 'echo hi' });
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/src/agentSessionCore/execTool.ts
+++ b/src/agentSessionCore/execTool.ts
@@ -1,0 +1,94 @@
+import { Tool } from '../copilotSdk/boundary';
+import { RUN_TERMINAL_DOCKER_TOOL } from '../config/tools';
+import { getExecCommand } from '../workspace';
+import { sanitizeSensitives } from '../utils/sanitizers';
+import { truncateOutput } from '../utils/formatters';
+
+export interface ExecToolResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number | null;
+}
+
+export interface ExecToolStreamEvent {
+  readonly toolName: string;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number | null;
+}
+
+/**
+ * SYS-REQ-029h: output delivery is orthogonal to the lock decision. A
+ * consumer that wants results forwarded to an external stream (e.g. an SSE
+ * response) supplies `onDeliver`; a consumer that doesn't want streaming
+ * simply omits it. Neither choice touches the traversal-check/sanitization
+ * logic below (SYS-REQ-029d), and neither reads orchestration-session state
+ * (SYS-REQ-029e) -- that decision is made one layer up, by whether
+ * `SessionWrapper.onPermissionRequest` lets the call through at all.
+ */
+export interface ExecToolHandlerOptions {
+  readonly abortSignal?: AbortSignal;
+  readonly sensitiveValuesCache?: Set<string> | null;
+  readonly onDeliver?: (event: ExecToolStreamEvent) => Promise<void> | void;
+  readonly writeLog?: (message: string) => void;
+}
+
+/**
+ * SYS-REQ-029d: the single implementation of the shell-exec tool's
+ * working-directory traversal check and output sanitization, shared by
+ * every caller regardless of lock policy or delivery mode. This function
+ * intentionally does NOT consult orchestration-session state (SYS-REQ-029e)
+ * -- availability is decided entirely by whether `SessionWrapper` invokes
+ * this handler in the first place.
+ */
+export function createExecToolHandler(options: ExecToolHandlerOptions = {}) {
+  const { abortSignal, sensitiveValuesCache, onDeliver, writeLog } = options;
+
+  return async (args: unknown): Promise<ExecToolResult> => {
+    const record = (args as Record<string, unknown>) ?? {};
+    const command = (record.command as string) || '';
+    const workingDir = (record.workingDir as string) || '';
+
+    if (workingDir.includes('..')) {
+      writeLog?.(`[run_terminal_docker] Traversal path attempt blocked: ${workingDir}`);
+      return {
+        stdout: '',
+        stderr: 'Error: Directory path traversal detected. Access denied outside workspace boundaries.',
+        exitCode: 1,
+      };
+    }
+
+    const execCommand = getExecCommand();
+    const result = await execCommand(command, abortSignal);
+
+    const stdout = truncateOutput(sanitizeSensitives(result.stdout, sensitiveValuesCache || new Set<string>()));
+    const stderr = truncateOutput(sanitizeSensitives(result.stderr, sensitiveValuesCache || new Set<string>()));
+
+    if (onDeliver) {
+      await onDeliver({
+        toolName: RUN_TERMINAL_DOCKER_TOOL.function.name,
+        stdout,
+        stderr,
+        exitCode: result.exitCode,
+      });
+    }
+
+    return { stdout, stderr, exitCode: result.exitCode };
+  };
+}
+
+/**
+ * SYS-REQ-029b: the single factory for the containerized shell-exec tool
+ * definition, replacing the three independent `RUN_TERMINAL_DOCKER_TOOL.
+ * function.*` -> `Tool` mappings this issue was opened to consolidate.
+ * Schema values are sourced once, here, from `RUN_TERMINAL_DOCKER_TOOL` so
+ * the wire contract itself still has a single source of truth.
+ */
+export function createExecTool(options: ExecToolHandlerOptions = {}): Tool {
+  return {
+    name: RUN_TERMINAL_DOCKER_TOOL.function.name,
+    description: RUN_TERMINAL_DOCKER_TOOL.function.description,
+    parameters: RUN_TERMINAL_DOCKER_TOOL.function.parameters,
+    handler: createExecToolHandler(options),
+  };
+}

--- a/src/agentSessionCore/index.ts
+++ b/src/agentSessionCore/index.ts
@@ -1,0 +1,4 @@
+export { createExecTool, createExecToolHandler } from './execTool';
+export type { ExecToolHandlerOptions, ExecToolResult, ExecToolStreamEvent } from './execTool';
+export { createAgentSession } from './sessionFactory';
+export type { AgentSession, RegisteredTool, ToolLockPolicy } from './sessionFactory';

--- a/src/agentSessionCore/lockPolicy.typecheck.ts
+++ b/src/agentSessionCore/lockPolicy.typecheck.ts
@@ -1,0 +1,20 @@
+// SYS-REQ-029f: omitting the lock selection for a lock-eligible tool must
+// be a compile-time error. This file is exercised only by `tsc --noEmit`
+// (it is not a vitest test, and asserts nothing at runtime) -- each
+// `@ts-expect-error` below fails the build if the following statement
+// *stops* being a type error, which is exactly the regression this guards.
+import type { ToolLockPolicy } from './sessionFactory';
+
+// Valid: both variants require `mode` and `rationale`, nothing else is optional-away.
+const locked: ToolLockPolicy = { mode: 'locked', rationale: 'gate on live orchestration state' };
+const unlocked: ToolLockPolicy = { mode: 'unlocked', rationale: 'always available, no session dependency' };
+void locked;
+void unlocked;
+
+// @ts-expect-error -- `mode` is required; there is no default lock selection.
+const missingMode: ToolLockPolicy = { rationale: 'no mode supplied' };
+void missingMode;
+
+// @ts-expect-error -- `rationale` is required for every lock selection (SYS-REQ-029i).
+const missingRationale: ToolLockPolicy = { mode: 'locked' };
+void missingRationale;

--- a/src/agentSessionCore/sessionFactory.test.ts
+++ b/src/agentSessionCore/sessionFactory.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createAgentSession } from './sessionFactory';
+import { createExecTool } from './execTool';
+
+function fakeTool(name: string) {
+  return {
+    name,
+    description: `fake tool ${name}`,
+    parameters: { type: 'object', properties: {} },
+    handler: vi.fn(async () => 'ok'),
+  };
+}
+
+function customToolRequest(toolName: string) {
+  return { kind: 'custom-tool', toolName } as never;
+}
+
+describe('createAgentSession (SYS-REQ-029c): tool-agnostic factory', () => {
+  it('registers the exec tool alongside an arbitrary non-exec tool in the same SessionWrapper', async () => {
+    const execTool = createExecTool();
+    const other = fakeTool('run_tests');
+
+    const { wrapper } = createAgentSession(undefined, [
+      { tool: execTool, lock: { mode: 'unlocked', rationale: 'test: always available' } },
+      { tool: other, lock: { mode: 'unlocked', rationale: 'test: always available' } },
+    ]);
+
+    const config = wrapper._createConfig();
+    expect(config.availableTools).toEqual(expect.arrayContaining(['run_terminal_docker', 'run_tests']));
+    await expect(config.onPermissionRequest(customToolRequest('run_terminal_docker'), { sessionId: 's1' }))
+      .resolves.toMatchObject({ kind: 'approve-once' });
+    await expect(config.onPermissionRequest(customToolRequest('run_tests'), { sessionId: 's1' }))
+      .resolves.toMatchObject({ kind: 'approve-once' });
+  });
+});
+
+describe('createAgentSession: lock policy as enablement, not a parallel gate (SYS-REQ-029e/029f/029g)', () => {
+  it('locked + no active orchestration session -> disabled at the permission layer, schema still present', async () => {
+    const execTool = createExecTool();
+    const { wrapper, applyLockPolicy } = createAgentSession(undefined, [
+      { tool: execTool, lock: { mode: 'locked', rationale: 'test: gate on orchestration state', getAutoApproveAll: () => false } },
+    ]);
+
+    applyLockPolicy();
+    const config = wrapper._createConfig();
+
+    // Schema stays declared (SYS-REQ-028/028d) even though the call will be rejected.
+    expect(config.availableTools).toContain('run_terminal_docker');
+    await expect(config.onPermissionRequest(customToolRequest('run_terminal_docker'), { sessionId: 's1' }))
+      .resolves.toMatchObject({ kind: 'reject' });
+  });
+
+  it('locked + active orchestration session (simulated via getAutoApproveAll) -> enabled', async () => {
+    const execTool = createExecTool();
+    const { wrapper, applyLockPolicy } = createAgentSession(undefined, [
+      { tool: execTool, lock: { mode: 'locked', rationale: 'test: gate on orchestration state', getAutoApproveAll: () => true } },
+    ]);
+
+    applyLockPolicy();
+    const config = wrapper._createConfig();
+
+    await expect(config.onPermissionRequest(customToolRequest('run_terminal_docker'), { sessionId: 's1' }))
+      .resolves.toMatchObject({ kind: 'approve-once' });
+  });
+
+  it('unlocked tool stays enabled regardless of orchestration state, without applyLockPolicy touching it', async () => {
+    const other = fakeTool('run_tests');
+    const { wrapper, applyLockPolicy } = createAgentSession(undefined, [
+      { tool: other, lock: { mode: 'unlocked', rationale: 'test: no session dependency' } },
+    ]);
+
+    applyLockPolicy(); // no locked tools registered -> no-op
+    const config = wrapper._createConfig();
+
+    await expect(config.onPermissionRequest(customToolRequest('run_tests'), { sessionId: 's1' }))
+      .resolves.toMatchObject({ kind: 'approve-once' });
+  });
+
+  it('re-evaluates per call to applyLockPolicy (per-turn), not just once at construction', async () => {
+    const execTool = createExecTool();
+    let approved = false;
+    const { wrapper, applyLockPolicy } = createAgentSession(undefined, [
+      { tool: execTool, lock: { mode: 'locked', rationale: 'test: per-turn re-check', getAutoApproveAll: () => approved } },
+    ]);
+
+    applyLockPolicy();
+    let config = wrapper._createConfig();
+    await expect(config.onPermissionRequest(customToolRequest('run_terminal_docker'), { sessionId: 's1' }))
+      .resolves.toMatchObject({ kind: 'reject' });
+
+    approved = true;
+    applyLockPolicy();
+    config = wrapper._createConfig();
+    await expect(config.onPermissionRequest(customToolRequest('run_terminal_docker'), { sessionId: 's1' }))
+      .resolves.toMatchObject({ kind: 'approve-once' });
+  });
+});

--- a/src/agentSessionCore/sessionFactory.ts
+++ b/src/agentSessionCore/sessionFactory.ts
@@ -1,0 +1,71 @@
+import { CopilotClient, Tool } from '../copilotSdk/boundary';
+import { SessionWrapper, SessionWrapperBaseConfig } from '../copilotSdk/sessionWrapper';
+import { checkActiveOrchestrationSession } from '../orchestrator/sessionState';
+
+/**
+ * SYS-REQ-029f: a lock-eligible tool must be explicitly declared locked or
+ * unlocked -- there is no default. `rationale` makes that choice visible at
+ * the call site (SYS-REQ-029i); it's not read by any logic below and exists
+ * purely as an enforced code comment.
+ */
+export type ToolLockPolicy =
+  | { readonly mode: 'locked'; readonly rationale: string; readonly getAutoApproveAll?: () => boolean }
+  | { readonly mode: 'unlocked'; readonly rationale: string };
+
+export interface RegisteredTool {
+  readonly tool: Tool;
+  readonly lock: ToolLockPolicy;
+}
+
+/**
+ * A tool-agnostic session bundle (SYS-REQ-029c). `wrapper` is the plain
+ * `SessionWrapper` -- callers pass it to `runForcedToolTurn`/
+ * `runForcedToolTurnUntilTimeout`/`sendAndWait` exactly as they would any
+ * other `SessionWrapper`. `applyLockPolicy` is the SYS-REQ-029e/f mechanism:
+ * it must be called once immediately before every outgoing turn (i.e.
+ * immediately before each `wrapper.sendAndWait(...)`), and it is the *only*
+ * place orchestration-session state is consulted for these tools -- the
+ * tool handlers themselves never read it (SYS-REQ-029e). This is a call
+ * site obligation rather than something the unit can enforce by itself
+ * without owning the turn loop; migrating existing turn loops to call it is
+ * tracked on the follow-up issues (#416/#417), not this one.
+ */
+export interface AgentSession {
+  readonly wrapper: SessionWrapper;
+  applyLockPolicy(): void;
+}
+
+/**
+ * SYS-REQ-029c: builds a `SessionWrapper` from an arbitrary set of tool
+ * definitions (not just the shell-exec tool), each with its own lock
+ * policy. All tools are registered as `custom` so `SessionWrapper` owns
+ * dispatch (SYS-REQ-028a) uniformly across the whole set.
+ */
+export function createAgentSession(
+  client: CopilotClient | undefined,
+  tools: readonly RegisteredTool[],
+  baseConfig: SessionWrapperBaseConfig = {}
+): AgentSession {
+  const wrapper = new SessionWrapper(client, { custom: tools.map((t) => t.tool) }, baseConfig);
+
+  const lockedTools = tools.filter(
+    (t): t is RegisteredTool & { lock: Extract<ToolLockPolicy, { mode: 'locked' }> } => t.lock.mode === 'locked'
+  );
+
+  function applyLockPolicy(): void {
+    for (const { tool, lock } of lockedTools) {
+      // SYS-REQ-029e: this is the sole place lock-eligible tools' enablement
+      // is decided. Rejection of a disabled tool's call still happens
+      // exclusively inside `SessionWrapper.onPermissionRequest`
+      // (SYS-REQ-028d) -- this only ever calls enableTools/disableTools.
+      const gate = checkActiveOrchestrationSession(lock.getAutoApproveAll?.() ?? false, tool.name);
+      if (gate.ok) {
+        wrapper.enableTools(tool.name);
+      } else {
+        wrapper.disableTools(tool.name);
+      }
+    }
+  }
+
+  return { wrapper, applyLockPolicy };
+}


### PR DESCRIPTION
Adds src/agentSessionCore/ as a standalone, tool-agnostic unit per the merged spec (docs/agentSessionCore-spec.md, SYS-REQ-029 family):

- execTool.ts: single canonical run_terminal_docker Tool factory (SYS-REQ-029b) plus one shared handler implementation for the traversal check and output sanitization (SYS-REQ-029d), independent of lock policy or delivery mode. The handler never reads orchestration-session state itself (SYS-REQ-029e).
- sessionFactory.ts: createAgentSession() builds a SessionWrapper from an arbitrary set of tools (SYS-REQ-029c), each with an explicit, no-default lock policy (SYS-REQ-029f, enforced at compile time -- see lockPolicy.typecheck.ts) and a required rationale (SYS-REQ-029i). The returned applyLockPolicy() is the sole place orchestration state is queried, and it acts only through SessionWrapper.enableTools/ disableTools -- rejection of a disabled call still happens inside SessionWrapper.onPermissionRequest, not a second gate (SYS-REQ-029g). Output delivery (streamed/unstreamed) is independently selectable from lock policy via execTool's onDeliver option (SYS-REQ-029h).

Per the issue's build approach (hotswap), this is built and tested standalone: no existing call site (auditorHelper.ts, toolHandlers.ts, gateLoop.ts, verify-run-terminal-docker.ts, audit-codebase.ts) is touched here. Migration is tracked on #416/#417.

Full suite (npx tsc --noEmit && npx vitest run) passes: 382/382.