### PR TITLE
Exempt comment-only source changes from the spec-change PR isolation …

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,8 @@ Auditor agents **SHALL NEVER** propose changing the spec to match the implementa
 
 Any change to a spec document **SHALL** be made in its own pull request containing only spec changes — no source code, no test changes, and no implementation changes bundled in the same PR or commit range. This applies regardless of whether the change originated from an agent's escalation or a human's own initiative.
 
+**Exception — comment-only source changes:** A source file edit that touches only comments (no executable code, no test assertions, no behavior change) **MAY** be bundled into a spec-change PR when it exists solely to keep an in-code label from colliding with or contradicting spec-document terminology introduced or renamed by that same PR (e.g. renaming an ad hoc in-code tier/stage label that a new spec section's own numbering scheme would otherwise be confused with). The PR description **SHALL** call out any such comment-only change explicitly and explain the collision it resolves. This exception does not extend to renaming identifiers, docstrings that describe behavior, or any change a linter/type-checker would need to re-validate.
+
 Agents **SHALL NOT** open a spec-change PR on their own initiative. A spec PR may only be opened after a human has reviewed and confirmed a flagged spec error per the escalation process above.
 
 ### What Qualifies for an EARS item? **CRITICAL**


### PR DESCRIPTION
…… (#460)
…rule

Per human confirmation (spec-change escalation path, AGENTS.md 'Spec changes require an independent PR'). Adds a narrow exception: a source-file edit touching only comments may be bundled into a spec-change PR when its sole purpose is resolving a naming collision with terminology the same PR introduces or renames in the spec doc (e.g. an in-code tier/stage label vs. a new spec section's numbering). Does not extend to identifier renames, behavior-describing docstrings, or anything a linter/type-checker would re-validate. PR description must call out the comment-only change and the specific collision it resolves.

This is its own PR containing only this AGENTS.md change, per the rule it amends.